### PR TITLE
Treat filters as form so we can press enter to submit

### DIFF
--- a/packages/tadviewer/src/components/FilterEditor.tsx
+++ b/packages/tadviewer/src/components/FilterEditor.tsx
@@ -78,6 +78,11 @@ export const FilterEditor: React.FunctionComponent<FilterEditorProps> = ({
     onDone();
   };
 
+  const handleFormSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    handleApply();
+  };
+
   const feRows = opArgs.map((re, idx) => {
     return (
       <FilterEditorRow
@@ -93,7 +98,7 @@ export const FilterEditor: React.FunctionComponent<FilterEditorProps> = ({
   });
 
   return (
-    <div className="filter-editor">
+    <form className="filter-editor" onSubmit={handleFormSubmit}>
       <div className="filter-editor-filter-pane">
         <div className="filter-editor-select-row">
           <div className="bp3-select bp3-minimal">
@@ -126,6 +131,6 @@ export const FilterEditor: React.FunctionComponent<FilterEditorProps> = ({
         onApply={handleApply}
         onDone={handleDone}
       />
-    </div>
+    </form>
   );
 };


### PR DESCRIPTION
In #101 there are some keyboard shortcuts defined. I personally really like to use Enter to apply filters. 

I can't test this sadly because my local tad fails to start after following the building instructions
```
App threw an error during load
Error: dlopen(/Users/[...]/dev/tad/node_modules/ac-node-duckdb/build/Release/node-duckdb-addon.node, 1): Library not loaded: /usr/local/opt/openssl@3/lib/libcrypto.3.dylib
  Referenced from: /Users/[...]/dev/tad/node_modules/ac-node-duckdb/build/Release/node-duckdb-addon.node
  Reason: image not found
  ```

But I've written this sort of feature in tons of web apps so I assume this will work here as well.  
  