### PR TITLE
Add error callback to PivotRequester

### DIFF
--- a/packages/tadviewer/src/PivotRequester.ts
+++ b/packages/tadviewer/src/PivotRequester.ts
@@ -239,13 +239,16 @@ export class PivotRequester {
   pendingOffset: number;
   pendingLimit: number;
 
-  constructor(stateRef: oneref.StateRef<AppState>) {
+  errorCallback?: (e: any) => void;
+
+  constructor(stateRef: oneref.StateRef<AppState>, errorCallback?: (e: any) => void) {
     this.pendingQueryRequest = null;
     this.currentQueryView = null;
     this.pendingDataRequest = null;
     this.pendingViewParams = null;
     this.pendingOffset = 0;
     this.pendingLimit = 0;
+    this.errorCallback = errorCallback;
     addStateChangeListener(stateRef, (_) => {
       this.onStateChange(stateRef);
     });
@@ -369,12 +372,16 @@ export class PivotRequester {
           oneref.update(
             stateRef,
             vsUpdate(
-              (vs: ViewState) =>
-                vs
-                  .update("loadingTimer", (lt) => lt.stop())
-                  .set("viewParams", prevViewParams) as ViewState
+              (vs: ViewState) => {
+                return vs
+                  .update("loadingTimer", (lt) => lt.stop());
+              }
             )
           );
+          if (this.errorCallback) {
+            this.errorCallback(err);
+          }
+
         });
       const ltUpdater = util.pathUpdater<AppState, Timer>(stateRef, [
         "viewState",

--- a/packages/tadviewer/src/PivotRequester.ts
+++ b/packages/tadviewer/src/PivotRequester.ts
@@ -372,10 +372,9 @@ export class PivotRequester {
           oneref.update(
             stateRef,
             vsUpdate(
-              (vs: ViewState) => {
-                return vs
-                  .update("loadingTimer", (lt) => lt.stop());
-              }
+              (vs: ViewState) =>
+                vs
+                  .update("loadingTimer", (lt) => lt.stop())
             )
           );
           if (this.errorCallback) {

--- a/packages/tadviewer/src/components/TadViewerPane.tsx
+++ b/packages/tadviewer/src/components/TadViewerPane.tsx
@@ -53,11 +53,13 @@ function TadViewerPaneInner({ stateRef, baseQuery }: TadViewerPaneInnerProps) {
 export interface TadViewerPaneProps {
   baseSqlQuery: string;
   dsConn: DataSourceConnection;
+  errorCallback?: (e: any) => void;
 }
 
 export function TadViewerPane({
   baseSqlQuery,
   dsConn,
+  errorCallback,
 }: TadViewerPaneProps): JSX.Element | null {
   const [appStateRef, setAppStateRef] = useState<StateRef<AppState> | null>(
     null
@@ -84,7 +86,7 @@ export function TadViewerPane({
         log.debug("*** initializing app state:");
         await initAppState(rtc, stateRef);
         log.debug("*** initialized Tad App state");
-        const preq = new PivotRequester(stateRef);
+        const preq = new PivotRequester(stateRef, errorCallback);
         log.debug("*** created pivotRequester");
         setPivotRequester(preq);
         log.debug("*** App component created and pivotrequester initialized");


### PR DESCRIPTION
Adding the callback should be a non-breaking change because it's optional.

There is also a change in behavior in this PR:  removing the line in the error handler that used to revert to previous view parameters in case of error. My reasoning here is that `PivotRequester` always queries the original data source if it detects a change in view parameters. But the original `baseQuery` remains unchanged, so the same "bad" query will keep getting reissued forever.