### PR TITLE
Expose an optional loading signal from tad

### DIFF
--- a/packages/tadviewer/src/PivotRequester.ts
+++ b/packages/tadviewer/src/PivotRequester.ts
@@ -217,6 +217,8 @@ function getObjectDiff(obj1: any, obj2: any) {
   return diff;
 }
 
+const noopSetLoading = (loading: boolean) => {};
+
 /**
  * A PivotRequester listens for changes on the appState and viewport and
  * manages issuing of query requests
@@ -238,10 +240,14 @@ export class PivotRequester {
 
   pendingOffset: number;
   pendingLimit: number;
-
   errorCallback?: (e: Error) => void;
+  setLoading: (loading: boolean) => void;
 
-  constructor(stateRef: oneref.StateRef<AppState>, errorCallback?: (e: Error) => void) {
+  constructor(
+    stateRef: oneref.StateRef<AppState>,
+    errorCallback?: (e: Error) => void,
+    setLoading?: (loading: boolean) => void
+  ) {
     this.pendingQueryRequest = null;
     this.currentQueryView = null;
     this.pendingDataRequest = null;
@@ -249,6 +255,8 @@ export class PivotRequester {
     this.pendingOffset = 0;
     this.pendingLimit = 0;
     this.errorCallback = errorCallback;
+    this.setLoading = setLoading || noopSetLoading;
+
     addStateChangeListener(stateRef, (_) => {
       this.onStateChange(stateRef);
     });
@@ -262,6 +270,7 @@ export class PivotRequester {
     stateRef: oneref.StateRef<AppState>,
     queryView: QueryView
   ): Promise<PagedDataView> {
+    this.setLoading(true);
     const appState: AppState = mutableGet(stateRef);
     const viewState = appState.viewState;
     const viewParams = viewState.viewParams;
@@ -290,6 +299,7 @@ export class PivotRequester {
               .set("dataView", dataView) as ViewState
         )
       );
+      this.setLoading(false);
       return dataView;
     });
     return dreq;
@@ -367,6 +377,7 @@ export class PivotRequester {
             err.message,
             err.stack
           );
+          this.setLoading(false);
           // TODO:
           // remoteErrorDialog("Error constructing view", err.message); // Now let's try and restore to previous view params:
           oneref.update(
@@ -377,10 +388,6 @@ export class PivotRequester {
                   .update("loadingTimer", (lt) => lt.stop())
             )
           );
-          if (this.errorCallback) {
-            this.errorCallback(err instanceof Error ? err : new Error(err));
-          }
-
         });
       const ltUpdater = util.pathUpdater<AppState, Timer>(stateRef, [
         "viewState",

--- a/packages/tadviewer/src/components/TadViewerPane.tsx
+++ b/packages/tadviewer/src/components/TadViewerPane.tsx
@@ -54,12 +54,14 @@ export interface TadViewerPaneProps {
   baseSqlQuery: string;
   dsConn: DataSourceConnection;
   errorCallback?: (e: Error) => void;
+  setLoading: (loading: boolean) => void;
 }
 
 export function TadViewerPane({
   baseSqlQuery,
   dsConn,
   errorCallback,
+  setLoading,
 }: TadViewerPaneProps): JSX.Element | null {
   const [appStateRef, setAppStateRef] = useState<StateRef<AppState> | null>(
     null
@@ -86,7 +88,7 @@ export function TadViewerPane({
         log.debug("*** initializing app state:");
         await initAppState(rtc, stateRef);
         log.debug("*** initialized Tad App state");
-        const preq = new PivotRequester(stateRef, errorCallback);
+        const preq = new PivotRequester(stateRef, errorCallback, setLoading);
         log.debug("*** created pivotRequester");
         setPivotRequester(preq);
         log.debug("*** App component created and pivotrequester initialized");

--- a/packages/tadviewer/src/components/TadViewerPane.tsx
+++ b/packages/tadviewer/src/components/TadViewerPane.tsx
@@ -54,14 +54,14 @@ export interface TadViewerPaneProps {
   baseSqlQuery: string;
   dsConn: DataSourceConnection;
   errorCallback?: (e: Error) => void;
-  setLoading: (loading: boolean) => void;
+  setLoadingCallback: (loading: boolean) => void;
 }
 
 export function TadViewerPane({
   baseSqlQuery,
   dsConn,
   errorCallback,
-  setLoading,
+  setLoadingCallback,
 }: TadViewerPaneProps): JSX.Element | null {
   const [appStateRef, setAppStateRef] = useState<StateRef<AppState> | null>(
     null
@@ -88,7 +88,7 @@ export function TadViewerPane({
         log.debug("*** initializing app state:");
         await initAppState(rtc, stateRef);
         log.debug("*** initialized Tad App state");
-        const preq = new PivotRequester(stateRef, errorCallback, setLoading);
+        const preq = new PivotRequester(stateRef, errorCallback, setLoadingCallback);
         log.debug("*** created pivotRequester");
         setPivotRequester(preq);
         log.debug("*** App component created and pivotrequester initialized");


### PR DESCRIPTION
`setLoading` will likely someday want to become `updateProgress`, so we can show a progress bar, but for now I named it for consistency with hatchling.

The callback is optional, to avoid affecting the standalone Tad apps.

Having a `setLoading` callback available through the component chain will allow us to measure query time accurately, too, I think. If `setLoading` measures time between the first `true` and the first `false` parameter invocations, but that's out of scope for the current PR.