### PR TITLE
add option for whether to display the record count column

### DIFF
--- a/packages/aggtree/src/aggtree.ts
+++ b/packages/aggtree/src/aggtree.ts
@@ -344,12 +344,15 @@ export class VPivotTree {
 }
 export const getBaseSchema = (
   rt: DataSourceConnection,
-  baseQuery: QueryExp
+  baseQuery: QueryExp,
+  showRecordCount = true
 ): Promise<Schema> => {
   // add a count column and do the usual SQL where 1=0 trick:
-  const schemaQuery = baseQuery
-    .extend("Rec", constVal(1))
-    .filter(reltab.and().eq(constVal(1), constVal(0)));
+  let schemaQuery = baseQuery.filter(reltab.and().eq(constVal(1), constVal(0)));
+  if (showRecordCount) {
+    schemaQuery = schemaQuery.extend("Rec", constVal(1));
+  }
+
   const schemap = rt.evalQuery(schemaQuery);
   return schemap.then((schemaRes) => schemaRes.schema);
 };
@@ -366,11 +369,14 @@ export function vpivot(
         [cid: string]: reltab.AggFn;
       }
     | undefined
-    | null = null
+    | null = null,
+  showRecordCount = true
 ): VPivotTree {
   const aggMap = inAggMap; // just for Flow
 
-  baseQuery = baseQuery.extend("Rec", constVal(1));
+  if (showRecordCount) {
+    baseQuery = baseQuery.extend("Rec", constVal(1));
+  }
   const hiddenCols = ["_depth", "_pivot", "_isRoot"];
   const outCols = baseSchema.columns.concat(hiddenCols);
   const gbCols = baseSchema.columns.slice();

--- a/packages/tadviewer/src/AppState.ts
+++ b/packages/tadviewer/src/AppState.ts
@@ -27,6 +27,7 @@ export interface AppStateProps {
 
   appLoadingTimer: Timer;
   activity: Activity;
+  showRecordCount: boolean;
 }
 
 const defaultAppStateProps: AppStateProps = {
@@ -41,6 +42,7 @@ const defaultAppStateProps: AppStateProps = {
   viewConfirmSourcePath: null,
   appLoadingTimer: new Timer(),
   activity: "None",
+  showRecordCount: true,
 };
 
 export class AppState extends Immutable.Record(defaultAppStateProps) {
@@ -58,4 +60,5 @@ export class AppState extends Immutable.Record(defaultAppStateProps) {
   public readonly viewConfirmSourcePath!: DataSourcePath | null;
   public readonly appLoadingTimer!: Timer;
   public readonly activity!: Activity;
+  public readonly showRecordCount!: boolean;
 }

--- a/packages/tadviewer/src/PivotRequester.ts
+++ b/packages/tadviewer/src/PivotRequester.ts
@@ -132,7 +132,8 @@ const requestQueryView = async (
   rt: DataSourceConnection,
   baseQuery: reltab.QueryExp,
   baseSchema: reltab.Schema,
-  viewParams: ViewParams
+  viewParams: ViewParams,
+  showRecordCount: boolean
 ): Promise<QueryView> => {
   const schemaCols = baseSchema.columns;
   const aggMap: any = {};
@@ -150,7 +151,8 @@ const requestQueryView = async (
     viewParams.pivotLeafColumn,
     viewParams.showRoot,
     viewParams.sortKey,
-    aggMap
+    aggMap,
+    showRecordCount
   );
   const treeQuery = await ptree.getSortedTreeQuery(viewParams.openPaths); // const t0 = performance.now()  // eslint-disable-line
 
@@ -342,7 +344,8 @@ export class PivotRequester {
         viewState.dbc,
         viewState.baseQuery,
         viewState.baseSchema,
-        this.pendingViewParams
+        this.pendingViewParams,
+        appState.showRecordCount
       );
       this.pendingQueryRequest = qreq;
       this.pendingDataRequest = qreq

--- a/packages/tadviewer/src/actions.ts
+++ b/packages/tadviewer/src/actions.ts
@@ -77,7 +77,10 @@ export const setQueryView = async (
   const baseSchema = await aggtree.getBaseSchema(dsc, baseQuery);
 
   // start off with all columns displayed:
-  const displayColumns = baseSchema.columns.slice();
+  const lastColumn = appState.showRecordCount
+    ? baseSchema.columns.length
+    : baseSchema.columns.length - 1;
+  const displayColumns = baseSchema.columns.slice(0, lastColumn);
 
   const openPaths = new PathTree();
   const initialViewParams = new ViewParams({

--- a/packages/tadviewer/src/actions.ts
+++ b/packages/tadviewer/src/actions.ts
@@ -74,13 +74,14 @@ export const setQueryView = async (
   // console.log("replaceCurrentView: queryTableName: ", dsPath, queryTableName);
 
   const baseQuery = reltab.sqlQuery(sqlQuery);
-  const baseSchema = await aggtree.getBaseSchema(dsc, baseQuery);
+  const baseSchema = await aggtree.getBaseSchema(
+    dsc,
+    baseQuery,
+    appState.showRecordCount
+  );
 
   // start off with all columns displayed:
-  const lastColumn = appState.showRecordCount
-    ? baseSchema.columns.length
-    : baseSchema.columns.length - 1;
-  const displayColumns = baseSchema.columns.slice(0, lastColumn);
+  const displayColumns = baseSchema.columns.slice();
 
   const openPaths = new PathTree();
   const initialViewParams = new ViewParams({
@@ -131,7 +132,11 @@ export const replaceCurrentView = async (
   // console.log("replaceCurrentView: queryTableName: ", dsPath, queryTableName);
 
   const baseQuery = reltab.tableQuery(queryTableName);
-  const baseSchema = await aggtree.getBaseSchema(dbc, baseQuery);
+  const baseSchema = await aggtree.getBaseSchema(
+    dbc,
+    baseQuery,
+    appState.showRecordCount
+  );
 
   // start off with all columns displayed:
   const displayColumns = baseSchema.columns.slice();

--- a/packages/tadviewer/src/components/TadViewerPane.tsx
+++ b/packages/tadviewer/src/components/TadViewerPane.tsx
@@ -55,7 +55,7 @@ export interface TadViewerPaneProps {
   dsConn: DataSourceConnection;
   errorCallback?: (e: Error) => void;
   setLoadingCallback: (loading: boolean) => void;
-  showRecordCount?: boolean;
+  showRecordCount: boolean;
 }
 
 export function TadViewerPane({

--- a/packages/tadviewer/src/components/TadViewerPane.tsx
+++ b/packages/tadviewer/src/components/TadViewerPane.tsx
@@ -55,6 +55,7 @@ export interface TadViewerPaneProps {
   dsConn: DataSourceConnection;
   errorCallback?: (e: Error) => void;
   setLoadingCallback: (loading: boolean) => void;
+  showRecordCount?: boolean;
 }
 
 export function TadViewerPane({
@@ -62,6 +63,7 @@ export function TadViewerPane({
   dsConn,
   errorCallback,
   setLoadingCallback,
+  showRecordCount,
 }: TadViewerPaneProps): JSX.Element | null {
   const [appStateRef, setAppStateRef] = useState<StateRef<AppState> | null>(
     null
@@ -82,7 +84,7 @@ export function TadViewerPane({
       log.debug("*** TadViewerPane: got local reltab connection: ", rtc);
 
       if (!appStateRef) {
-        const appState = new AppState();
+        const appState = new AppState({ showRecordCount });
         const stateRef = mkRef(appState);
         setAppStateRef(stateRef);
         log.debug("*** initializing app state:");


### PR DESCRIPTION
This is a purely visual change; the count query still executes but is not shown.

Another option would be to pass this flag to aggtree, too, to avoid running the count query. But having a record count seems generally useful for pagination, so I went with the minimal approach of removing the last "Rec" column from default view parameters if needed. I could also remove it by name explicitly if this is too fragile.

**End result if the `showRecordCount` option is missing or set to `false`:**
![image](https://user-images.githubusercontent.com/41136058/223489357-145bcc87-1859-4d10-ade1-6dbb8c2e701f.png)

**End result if `true` is passed through AppState:**
![image](https://user-images.githubusercontent.com/41136058/223487974-9c212bfb-43f9-4fb9-b98c-6b6f0061d831.png)
