### PR TITLE
add all available timestamp types to the column type map

### DIFF
--- a/packages/reltab/src/ColumnType.ts
+++ b/packages/reltab/src/ColumnType.ts
@@ -56,6 +56,9 @@ const defaultValRender: StringRenderFn = (val: any) => {
   if (typeof val === "bigint") {
     return val.toString();
   }
+  if (val instanceof Date) {
+    return val.toISOString();
+  }
   try {
     return String(val);
   } catch (err) {

--- a/packages/reltab/src/ColumnType.ts
+++ b/packages/reltab/src/ColumnType.ts
@@ -56,9 +56,6 @@ const defaultValRender: StringRenderFn = (val: any) => {
   if (typeof val === "bigint") {
     return val.toString();
   }
-  if (val instanceof Date) {
-    return val.toISOString();
-  }
   try {
     return String(val);
   } catch (err) {

--- a/packages/reltab/src/dialects/DuckDBDialect.ts
+++ b/packages/reltab/src/dialects/DuckDBDialect.ts
@@ -36,6 +36,8 @@ const createTimestampStringRenderer = (dateOnly = false) => ({
   },
 });
 
+// see https://duckdb.org/docs/sql/data_types/timestamp
+// for timestamp type coverage.
 const timestampCT = new ColumnType(
   "TIMESTAMP",
   "timestamp",

--- a/packages/reltab/src/dialects/DuckDBDialect.ts
+++ b/packages/reltab/src/dialects/DuckDBDialect.ts
@@ -74,6 +74,12 @@ const timestampWithTimeZoneCT = new ColumnType(
   createTimestampStringRenderer()
 );
 
+const timestampTZCT = new ColumnType(
+  "TIMESTAMPTZ",
+  "timestamp",
+  createTimestampStringRenderer()
+);
+
 const dateCT = new ColumnType(
   "DATE",
   "timestamp",
@@ -117,6 +123,7 @@ export class DuckDBDialectClass extends BaseSQLDialect {
     FLOAT: realCT,
     TEXT: textCT,
     TIMESTAMP: timestampCT,
+    TIMESTAMPTZ: timestampTZCT,
     "TIMESTAMP WITH TIME ZONE": timestampWithTimeZoneCT,
     TIMESTAMP_NS: timestampNSCT,
     TIMESTAMP_S: timestampSCT,

--- a/packages/reltab/src/dialects/DuckDBDialect.ts
+++ b/packages/reltab/src/dialects/DuckDBDialect.ts
@@ -7,7 +7,7 @@ const realCT = new ColumnType("DOUBLE", "real");
 const textCT = new ColumnType("VARCHAR", "string");
 const boolCT = new ColumnType("BOOL", "boolean");
 
-const timestampCT = new ColumnType("TIMESTAMP", "timestamp", {
+const createTimestampStringRenderer = (dateOnly = false) => ({
   stringRender: (val: any) => {
     if (val == null) {
       return "";
@@ -15,6 +15,7 @@ const timestampCT = new ColumnType("TIMESTAMP", "timestamp", {
     let retStr: string;
     try {
       retStr = new Date(val).toISOString();
+      if (dateOnly) retStr = retStr.split("T")[0];
     } catch (err) {
       if (err instanceof RangeError) {
         console.info(
@@ -34,6 +35,48 @@ const timestampCT = new ColumnType("TIMESTAMP", "timestamp", {
     return retStr;
   },
 });
+
+const timestampCT = new ColumnType(
+  "TIMESTAMP",
+  "timestamp",
+  createTimestampStringRenderer()
+);
+
+const timestampNSCT = new ColumnType(
+  "TIMESTAMP_NS",
+  "timestamp",
+  createTimestampStringRenderer()
+);
+
+const timestampSCT = new ColumnType(
+  "TIMESTAMP_S",
+  "timestamp",
+  createTimestampStringRenderer()
+);
+
+const timestampMSCT = new ColumnType(
+  "TIMESTAMP_MS",
+  "timestamp",
+  createTimestampStringRenderer()
+);
+
+const datetimeCT = new ColumnType(
+  "DATETIME",
+  "timestamp",
+  createTimestampStringRenderer()
+);
+
+const timestampWithTimeZoneCT = new ColumnType(
+  "TIMESTAMP WITH TIME ZONE",
+  "timestamp",
+  createTimestampStringRenderer()
+);
+
+const dateCT = new ColumnType(
+  "DATE",
+  "timestamp",
+  createTimestampStringRenderer(true)
+);
 
 const blobCT = new ColumnType("BLOB", "blob", {
   stringRender: (val: any) => {
@@ -72,6 +115,12 @@ export class DuckDBDialectClass extends BaseSQLDialect {
     FLOAT: realCT,
     TEXT: textCT,
     TIMESTAMP: timestampCT,
+    "TIMESTAMP WITH TIME ZONE": timestampWithTimeZoneCT,
+    TIMESTAMP_NS: timestampNSCT,
+    TIMESTAMP_S: timestampSCT,
+    TIMESTAMP_MS: timestampMSCT,
+    DATETIME: datetimeCT,
+    DATE: dateCT,
     VARCHAR: textCT,
     BOOL: boolCT,
     BOOLEAN: boolCT,


### PR DESCRIPTION
This PR adds all available timestamp types to the DuckDB dialect type map.