### PR TITLE
add basic css variables for font-family and font-size

### DIFF
--- a/packages/tadviewer/less/tadviewer.less
+++ b/packages/tadviewer/less/tadviewer.less
@@ -5,10 +5,10 @@
 @import "~@blueprintjs/popover2/lib/css/blueprint-popover2.css";
 
 .tad-app-pane {
+  font-family: var(--tad-font, "Helvetica Neue", Helvetica, Arial, sans-serif);
+  font-size: var(--tad-font-size, 8px);
   margin: 0;
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 400;
-  font-size: 8pt;
   height: 100%;
   overflow: hidden;
 }

--- a/packages/tadviewer/less/tadviewer.less
+++ b/packages/tadviewer/less/tadviewer.less
@@ -5,7 +5,7 @@
 @import "~@blueprintjs/popover2/lib/css/blueprint-popover2.css";
 
 .tad-app-pane {
-  font-family: var(--tad-font, "Helvetica Neue", Helvetica, Arial, sans-serif);
+  font-family: var(--tad-font-family, "Helvetica Neue", Helvetica, Arial, sans-serif);
   font-size: var(--tad-font-size, 8px);
   margin: 0;
   font-weight: 400;


### PR DESCRIPTION
It's not currently possible to change tad's styling in an application-specific way. The right way to enable applications to change basic elements of Tad's css is to thread in CSS variables, using Tad's current stylesheet values as the default. Using variables enables us to also change the implementation of Tad's styling while preserving application-specific choices.

With this in mind, this PR adds two variables to Tad: `--tad-font-family` and `--tad-font-size`.