### PR TITLE
extensible timestamp rendering for DuckDB

### DIFF
--- a/packages/reltab/src/dialects/DuckDBDialect.ts
+++ b/packages/reltab/src/dialects/DuckDBDialect.ts
@@ -7,10 +7,21 @@ const realCT = new ColumnType("DOUBLE", "real");
 const textCT = new ColumnType("VARCHAR", "string");
 const boolCT = new ColumnType("BOOL", "boolean");
 
+interface DuckDBStringRenderer {
+  toDuckDBString(): string;
+}
+
+function isDuckDBStringRenderer(val: any): val is DuckDBStringRenderer {
+  return val != null && typeof val === 'object' && !!(val as DuckDBStringRenderer).toDuckDBString;
+}
+
 const createTimestampStringRenderer = (dateOnly = false) => ({
   stringRender: (val: any) => {
     if (val == null) {
       return "";
+    }
+    if (isDuckDBStringRenderer(val)) {
+      return val.toDuckDBString();
     }
     let retStr: string;
     try {


### PR DESCRIPTION
When using the DuckDB dialect, if a timestamp value is an object with a `toDuckDBString` method, render the timestamp using that method instead of using JS Date to render it as an ISO string. This enables a wider range of rendering options for DuckDB timestamps, including matching the native DuckDB timestamp format.