### PR TITLE
enables `--tad-footer-font-size` css var and sets default to 14px

### DIFF
--- a/packages/tadviewer/less/footer.less
+++ b/packages/tadviewer/less/footer.less
@@ -6,7 +6,7 @@
   border: 1px solid #bababa;
   padding-top: 4px;
   padding-bottom: 4px;
-  font-size: 14px;
+  font-size: var(--tad-footer-font-size, 14px);
   flex: 0 0 auto;
   display: flex;
   justify-content: flex-start;


### PR DESCRIPTION
I've smoketested this and confirmed that this passes through the original 14px font size to the footer bar.