### PR TITLE
Refactor GridPane into DataGrid to isolate SlickGrid dependencies

### DIFF
--- a/packages/tadviewer/src/PagedDataView.ts
+++ b/packages/tadviewer/src/PagedDataView.ts
@@ -5,17 +5,26 @@ import * as reltab from "reltab";
  * some offset
  */
 
+// Note: This doesn't explicitly include the '_path' or "_sortVal_X_Y" columns
+export interface DataRow {
+  _isLeaf: boolean;
+  _depth: number;
+  _pivot: string;
+  _isOpen: boolean;
+  [columnId: string]: reltab.Scalar;
+}
+
 export class PagedDataView {
   schema: reltab.Schema;
   totalRowCount: number;
   offset: number;
-  rawData: Array<any>;
+  rawData: Array<DataRow>;
 
   constructor(
     schema: reltab.Schema,
     totalRowCount: number,
     offset: number,
-    items: Array<any>
+    items: Array<DataRow>
   ) {
     this.schema = schema;
     this.totalRowCount = totalRowCount;
@@ -35,7 +44,7 @@ export class PagedDataView {
     return this.rawData.length;
   }
 
-  getItem(index: number): any {
+  getItem(index: number): DataRow | null {
     let ret = null;
     const itemIndex = index - this.offset;
 

--- a/packages/tadviewer/src/PivotRequester.ts
+++ b/packages/tadviewer/src/PivotRequester.ts
@@ -1,7 +1,7 @@
 import log from "loglevel";
 import * as reltab from "reltab";
 import * as aggtree from "aggtree";
-import { PagedDataView } from "./PagedDataView";
+import { PagedDataView, DataRow } from "./PagedDataView";
 import { ViewParams } from "./ViewParams";
 import { AppState } from "./AppState";
 import { QueryView } from "./QueryView";
@@ -28,18 +28,13 @@ import _ from "lodash";
  * SlickGrid from reltab.TableRep
  */
 
-interface RowMap {
-  [s: string]: any;
-  _depth: number;
-}
-
 const mkDataView = (
   viewParams: ViewParams,
   rowCount: number,
   offset: number,
   tableData: reltab.TableRep
 ): PagedDataView => {
-  const getPath = (rowMap: RowMap, depth: number) => {
+  const getPath = (dataRow: DataRow, depth: number) => {
     let path: Array<string | null> = [];
 
     for (let i = 0; i < depth; i++) {
@@ -56,7 +51,7 @@ const mkDataView = (
 
   for (var i = 0; i < tableData.rowData.length; i++) {
     // ?? shouldn't we just be constructing the rowMap once and re-use it for every row??
-    var rowMap: RowMap = tableData.rowData[i] as RowMap;
+    var rowMap: DataRow = tableData.rowData[i] as DataRow;
     var depth: number = rowMap._depth;
     var path = getPath(rowMap, depth);
     rowMap._isOpen = viewParams.openPaths.isOpen(path);

--- a/packages/tadviewer/src/components/AppPane.tsx
+++ b/packages/tadviewer/src/components/AppPane.tsx
@@ -196,7 +196,6 @@ export const AppPane: React.FunctionComponent<AppPaneProps> = ({
   const { activity } = appState;
   const dataSourceExpanded = activity === "DataSource";
   const pivotPropsExpanded = activity === "Pivot";
-  const [grid, setGrid] = useState<any>(null);
   let mainContents: JSX.Element | null = null;
   const showDataSources =
     rawShowDataSources === undefined ? true : rawShowDataSources;
@@ -242,7 +241,6 @@ export const AppPane: React.FunctionComponent<AppPaneProps> = ({
       <div className="center-app-pane">
         {loadingModal}
         <GridPane
-          onSlickGridCreated={(grid) => setGrid(grid)}
           appState={appState}
           viewState={appState.viewState}
           stateRef={stateRef}

--- a/packages/tadviewer/src/components/DataGrid.tsx
+++ b/packages/tadviewer/src/components/DataGrid.tsx
@@ -1,0 +1,728 @@
+/**
+ *
+ * A DataGrid component, implemented using SlickGrid.
+ *
+ * This is a refactor of the original GridPane that decouples SlickGrid from Tad. The goal is to define a virtual DataGrid React
+ * component that does not have any Tad or SlickGrid details in the
+ */
+// for debugging resize handler:
+// import $ from 'jquery'
+import * as React from "react";
+import _ from "lodash";
+
+/* /// <reference path="slickgrid-es6.d.ts"> */
+import * as SlickGrid from "slickgrid-es6";
+import * as reltab from "reltab";
+import { LoadingModal } from "./LoadingModal";
+import { SimpleClipboard } from "./SimpleClipboard";
+import { DataRow, PagedDataView } from "../PagedDataView";
+import * as he from "he";
+import { useState, useRef } from "react";
+import log from "loglevel";
+
+const { Slick } = SlickGrid;
+const { Plugins } = SlickGrid as any;
+const { CellRangeSelector, CellSelectionModel, CellCopyManager, AutoTooltips } =
+  Plugins;
+import { ResizeEntry, ResizeSensor } from "@blueprintjs/core";
+import { ColumnType, NumericColumnHistogramData, Schema } from "reltab";
+import ReactDOM from "react-dom/client";
+import {
+  VictoryAxis,
+  VictoryBar,
+  VictoryBrushContainer,
+  VictoryChart,
+  VictoryTheme,
+} from "victory";
+import { CellFormatter } from "../FormatOptions";
+
+export type OpenURLFn = (url: string) => void;
+
+let divCounter = 0;
+
+const genContainerId = (): string => `epGrid${divCounter++}`;
+
+const baseGridOptions = {
+  multiColumnSort: true,
+  headerRowHeight: 80,
+};
+
+const INDENT_PER_LEVEL = 15; // pixels
+
+const calcIndent = (depth: number): number => INDENT_PER_LEVEL * depth;
+
+/*
+ * Formatter for cells in pivot column
+ */
+const groupCellFormatter = (
+  row: any,
+  cell: any,
+  value: any,
+  columnDef: any,
+  item: any
+) => {
+  const toggleCssClass = "slick-group-toggle";
+  const toggleExpandedCssClass = "expanded";
+  const toggleCollapsedCssClass = "collapsed";
+  const groupTitleCssClass = "slick-group-title";
+
+  var indentation = calcIndent(item._depth) + "px";
+
+  var pivotStr = item._pivot || "";
+
+  const expandClass = !item._isLeaf
+    ? item._isOpen
+      ? toggleExpandedCssClass
+      : toggleCollapsedCssClass
+    : "";
+  const ret = `
+<span class='${toggleCssClass} ${expandClass}' style='margin-left: ${indentation}'>
+</span>
+<span class='${groupTitleCssClass}' level='${item._depth}'>${pivotStr}</span>`;
+  return ret;
+};
+
+// scan table data to make best effort at initial column widths
+const MINCOLWIDTH = 150;
+const MAXCOLWIDTH = 300;
+
+// TODO: use real font metrics:
+const measureStringWidth = (s: string): number => 8 + 5.5 * s.length;
+const measureHeaderStringWidth = (s: string): number => 24 + 5.5 * s.length;
+
+// get column width for specific column:
+const getColWidth = (
+  getColumnFormatter: (schema: reltab.Schema, cid: string) => CellFormatter,
+  dataView: PagedDataView,
+  cnm: string
+) => {
+  const { schema } = dataView;
+  let sf: (val: any) => string;
+  if (schema.columnIndex(cnm)) {
+    const cf = getColumnFormatter(schema, cnm);
+    sf = (val: any) => cf(val) ?? val.toString();
+  } else {
+    sf = (val: any) => val.toString();
+  }
+  let colWidth;
+  const offset = dataView.getOffset();
+  const limit = offset + dataView.getItemCount();
+  for (var i = offset; i < limit; i++) {
+    var row = dataView.getItem(i);
+    var cellVal = row![cnm];
+    var cellWidth = MINCOLWIDTH;
+    if (cellVal) {
+      cellWidth = measureStringWidth(sf(cellVal));
+    }
+    if (cnm === "_pivot") {
+      cellWidth += calcIndent(row!._depth + 2);
+    }
+    colWidth = Math.min(
+      MAXCOLWIDTH,
+      Math.max(colWidth || MINCOLWIDTH, cellWidth)
+    );
+  }
+  const displayName = dataView.schema.displayName(cnm);
+  const headerStrWidth = measureHeaderStringWidth(displayName);
+  colWidth = Math.min(
+    MAXCOLWIDTH,
+    Math.max(colWidth || MINCOLWIDTH, headerStrWidth)
+  );
+  return colWidth;
+};
+
+type ColWidthMap = { [cid: string]: number };
+
+function getInitialColWidthsMap(
+  getColumnFormatter: (schema: reltab.Schema, cid: string) => CellFormatter,
+  dataView: PagedDataView
+): ColWidthMap {
+  // let's approximate the column width:
+  var colWidths: ColWidthMap = {};
+  var nRows = dataView.getLength();
+  if (nRows === 0) {
+    return {};
+  }
+  const initRow = dataView.getItem(0);
+  for (let cnm in initRow) {
+    colWidths[cnm] = getColWidth(getColumnFormatter, dataView, cnm);
+  }
+
+  return colWidths;
+}
+
+/*
+ * Construct map of SlickGrid column descriptors from base schema
+ * and column width info
+ *
+ * Map should contain entries for all column ids
+ */
+const mkSlickColMap = (
+  schema: reltab.Schema,
+  getColumnFormatter: (schema: reltab.Schema, cid: string) => CellFormatter,
+  getColumnCssClassName: (schema: reltab.Schema, cid: string) => string | null,
+  pivotColumnDisplayName: string,
+  colWidths: ColWidthMap
+) => {
+  let slickColMap: any = {};
+
+  // hidden columns:
+  slickColMap["_id"] = { id: "_id", field: "_id", name: "_id" };
+  slickColMap["_parentId"] = {
+    id: "_parentId",
+    field: "_parentId",
+    name: "_parentId",
+  };
+  for (let colId of schema.columns) {
+    let cmd = schema.columnMetadata[colId];
+    if (!cmd) {
+      console.error("could not find column metadata for ", colId, schema);
+    }
+    let ci: any = {
+      id: colId,
+      field: colId,
+      cssClass: "",
+      name: "",
+      formatter: null,
+    };
+    if (colId === "_pivot") {
+      ci.cssClass = "pivot-column";
+      ci.name = he.encode(pivotColumnDisplayName);
+      ci.toolTip = he.encode(pivotColumnDisplayName);
+      ci.formatter = groupCellFormatter;
+    } else {
+      var displayName = cmd.displayName || colId;
+      ci.name = he.encode(displayName);
+      ci.toolTip = he.encode(displayName);
+      ci.sortable = true;
+      const ff = getColumnFormatter(schema, colId);
+      const cellClass = getColumnCssClassName(schema, colId);
+      if (cellClass != null) {
+        ci.cssClass = cellClass;
+      }
+      ci.formatter = (
+        row: any,
+        cell: any,
+        value: any,
+        columnDef: any,
+        item: any
+      ) => (ff as any)(value);
+    }
+    ci.width = colWidths[colId];
+    slickColMap[colId] = ci;
+  }
+  return slickColMap;
+};
+
+interface NumericColumnHistogramProps {
+  histData: NumericColumnHistogramData;
+  colType: ColumnType;
+  onHistogramBrushRange?: (
+    colId: string,
+    range: [number, number] | null
+  ) => void;
+  onHistogramBrushFilter?: (
+    colId: string,
+    range: [number, number] | null
+  ) => void;
+}
+
+// gross hack to round to two decimal places:
+function round(value: number, decimals: number): number {
+  return Number(
+    Math.round(Number(value.toString() + "e" + decimals.toString())) +
+      "e-" +
+      decimals
+  );
+}
+const NumericColumnHistogram = ({
+  colType,
+  histData,
+  onHistogramBrushRange,
+  onHistogramBrushFilter,
+}: NumericColumnHistogramProps) => {
+  const {
+    colId,
+    binWidth,
+    niceMinVal,
+    niceMaxVal,
+    binData,
+    brushMinVal,
+    brushMaxVal,
+  } = histData;
+  const chartData = binData.map((count: number, binIndex: number) => ({
+    binMid: niceMinVal + (binIndex + 0.5) * binWidth,
+    count,
+  }));
+  const fmtOpts = {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+    useGrouping: true,
+  };
+
+  const handleBrush = (brushInfo: any) => {
+    onHistogramBrushRange?.(colId, brushInfo.x);
+  };
+  const handleBrushEnd = (brushInfo: any) => {
+    let [minVal, maxVal] = brushInfo.x;
+    if (colType.kind === "integer") {
+      minVal = Math.round(minVal);
+      maxVal = Math.round(maxVal);
+    } else {
+      minVal = round(minVal, 2);
+      maxVal = round(maxVal, 2);
+    }
+    onHistogramBrushFilter?.(colId, [minVal, maxVal]);
+  };
+
+  return (
+    <VictoryChart
+      padding={60}
+      domain={{ x: [niceMinVal, niceMaxVal + binWidth * 2] }}
+      containerComponent={
+        <VictoryBrushContainer
+          responsive={true}
+          brushDimension="x"
+          brushDomain={{ x: [brushMinVal, brushMaxVal] }}
+          onBrushDomainChange={handleBrush}
+          onBrushDomainChangeEnd={handleBrushEnd}
+        />
+      }
+    >
+      <VictoryAxis
+        tickValues={[niceMinVal, niceMaxVal]}
+        tickFormat={(tick: number) => tick.toLocaleString(undefined, fmtOpts)}
+        style={{
+          axis: { stroke: "none" },
+          tickLabels: { fontSize: 40 },
+        }}
+      />
+      <VictoryAxis
+        dependentAxis
+        tickCount={2}
+        style={{
+          axis: { stroke: "none" },
+          tickLabels: { fontSize: 40 },
+        }}
+      />
+      <VictoryBar
+        style={{ data: { fill: "rgb(25, 118, 210)" } }}
+        data={chartData}
+        x="binMid"
+        y="count"
+      />
+    </VictoryChart>
+  );
+};
+
+const getGridOptions = ({ showColumnHistograms, histoMap }: DataGridProps) => {
+  const histoCount = histoMap ? Object.keys(histoMap).length : 0;
+
+  const showHeaderRow = showColumnHistograms && histoCount > 0;
+  const gridOptions = {
+    ...baseGridOptions,
+    showHeaderRow,
+  };
+  return gridOptions;
+};
+
+// escape tabs by placing string in quotes
+function escapeTabs(cellData: any): any {
+  if (typeof cellData === "string" && cellData.indexOf("\t") >= 0) {
+    return '"' + cellData.replace(/"/g, '""') + '"';
+  }
+  return cellData;
+}
+
+/* Create grid from the specified set of columns */
+const createGrid = (
+  containerId: string,
+  columns: any,
+  dataView: any,
+  props: DataGridProps
+) => {
+  const {
+    histoMap,
+    onViewportChanged,
+    onHistogramBrushRange,
+    onHistogramBrushFilter,
+    onSetSortKey,
+    onGridClick,
+    onSetColumnOrder,
+    sortKey,
+    clipboard,
+    openURL,
+    embedded,
+  } = props;
+
+  const gridOptions = getGridOptions(props);
+  let grid = new Slick.Grid(`#${containerId}`, dataView, columns, gridOptions);
+
+  const selectionModel = new CellSelectionModel();
+  grid.setSelectionModel(selectionModel);
+  selectionModel.onSelectedRangesChanged.subscribe((e: any, args: any) => {
+    // TODO: could store this in app state and show some
+    // stats about selected range
+  });
+
+  const copyManager = new CellCopyManager();
+  grid.registerPlugin(copyManager);
+  grid.registerPlugin(new AutoTooltips({ enableForCells: true }));
+
+  const copySelectedRange = async (range: any) => {
+    let copyRowStrings: string[] = [];
+    const gridCols = grid.getColumns();
+    const gridData = grid.getData();
+    for (let row = range.fromRow; row <= range.toRow; row++) {
+      const rowData = gridData.getItem(row);
+      const copyRow = [];
+      for (let col = range.fromCell; col <= range.toCell; col++) {
+        const cid = gridCols[col].id;
+        copyRow.push(escapeTabs(rowData[cid]));
+      }
+      copyRowStrings.push(copyRow.join("\t"));
+    }
+    const copyData = copyRowStrings.join("\r\n") + "\r\n";
+    clipboard.writeText(copyData);
+  };
+
+  copyManager.onCopyCells.subscribe(async (e: any, args: any) => {
+    const range = args.ranges[0];
+    copySelectedRange(range);
+  });
+
+  // gross hack, but makes copy menu item work in Electron:
+  if (!embedded) {
+    document.addEventListener("copy", function (e) {
+      const ranges = grid.getSelectionModel().getSelectedRanges();
+      if (ranges && ranges.length != 0) {
+        copySelectedRange(ranges[0]);
+      }
+    });
+  }
+  const rangeSelector = new CellRangeSelector();
+
+  grid.registerPlugin(rangeSelector);
+
+  const updateViewportDebounced = _.debounce(() => {
+    const vp = grid.getViewport();
+    onViewportChanged?.(vp.top, vp.bottom);
+  }, 100);
+
+  grid.onViewportChanged.subscribe((e: any, args: any) => {
+    updateViewportDebounced();
+  });
+
+  grid.onHeaderRowCellRendered.subscribe((e: any, { node, column }: any) => {
+    console.log("onHeaderRowCellRendered: ", column);
+    if (dataView && histoMap && histoMap[column.id]) {
+      const histo = histoMap[column.id];
+      const colType = dataView.schema.columnType(column.id);
+      const root = ReactDOM.createRoot(node);
+      root.render(
+        <NumericColumnHistogram
+          histData={histo}
+          colType={colType}
+          onHistogramBrushRange={onHistogramBrushRange}
+          onHistogramBrushFilter={onHistogramBrushFilter}
+        />
+      );
+      node.classList.add("slick-editable");
+    } else {
+      console.log("*** no histo for column: ", column.id);
+    }
+  });
+
+  grid.onSort.subscribe((e: any, args: any) => {
+    // console.log("grid onSort: ", args);
+    // convert back from slickGrid format: */
+    const sortKey = args.sortCols.map((sc: any) => [
+      sc.sortCol.field,
+      sc.sortAsc,
+    ]);
+    onSetSortKey?.(sortKey);
+  });
+
+  const handleGridClick = (e: any, args: any) => {
+    // log.info("onGridClick: ", e, args);
+    const columns = grid.getColumns();
+    const col = columns[args.cell];
+    // log.info("onGridClick: column: ", col);
+    var item = grid.getDataItem(args.row);
+
+    onGridClick?.(args.row, args.cell, item, col.id, item[col.id]);
+  };
+
+  grid.onClick.subscribe(handleGridClick);
+
+  grid.onColumnsReordered.subscribe((e: any, args: any) => {
+    const cols = grid.getColumns();
+    const displayColIds = cols
+      .map((c: any) => c.field)
+      .filter((cid: any) => cid[0] !== "_");
+    onSetColumnOrder?.(displayColIds);
+  });
+
+  // load the first page
+  grid.onViewportChanged.notify();
+
+  return grid;
+};
+
+interface GridState {
+  grid: any;
+  colWidthsMap: ColWidthMap | null;
+  slickColMap: any;
+  containerId: string;
+}
+
+const updateColWidth = (
+  gs: GridState,
+  getColumnFormatter: (schema: reltab.Schema, cid: string) => CellFormatter,
+  dataView: PagedDataView,
+  colId: string
+) => {
+  const colWidth = getColWidth(getColumnFormatter, dataView, colId);
+  gs.colWidthsMap![colId] = colWidth;
+  gs.slickColMap[colId].width = colWidth;
+};
+
+// Get grid columns based on current column visibility settings:
+const getGridCols = (
+  gs: GridState,
+  isPivoted: boolean,
+  showHiddenColumns: boolean,
+  getColumnFormatter: (schema: reltab.Schema, cid: string) => CellFormatter,
+  dataView: PagedDataView,
+  displayColumns: string[]
+) => {
+  let gridCols = displayColumns.map((cid) => gs.slickColMap[cid]);
+  if (isPivoted) {
+    updateColWidth(gs, getColumnFormatter, dataView!, "_pivot");
+    let pivotCol = gs.slickColMap["_pivot"];
+    gridCols.unshift(pivotCol);
+  }
+  if (showHiddenColumns) {
+    const hiddenColIds = _.difference(
+      _.keys(gs.slickColMap),
+      gridCols.map((gc) => gc.field)
+    );
+    const hiddenCols = hiddenColIds.map((cid) => gs.slickColMap[cid]);
+    gridCols = gridCols.concat(hiddenCols);
+  }
+  return gridCols;
+};
+
+/*
+ * update grid from dataView
+ */
+const updateGrid = (gs: GridState, props: DataGridProps) => {
+  const {
+    dataView,
+    getColumnFormatter,
+    getColumnCssClassName,
+    isPivoted,
+    showHiddenColumns,
+    displayColumns,
+    pivotColumnDisplayName,
+    sortKey,
+  } = props;
+
+  gs.slickColMap = mkSlickColMap(
+    dataView!.schema,
+    getColumnFormatter,
+    getColumnCssClassName,
+    pivotColumnDisplayName ?? "",
+    gs.colWidthsMap!
+  );
+  const gridCols = getGridCols(
+    gs,
+    isPivoted!,
+    showHiddenColumns,
+    getColumnFormatter,
+    dataView!,
+    displayColumns
+  );
+
+  const grid = gs.grid;
+
+  const gridOptions = getGridOptions(props);
+  // console.log("updateGrid: gridOptions: ", gridOptions);
+
+  grid.setOptions(gridOptions);
+  grid.setHeaderRowVisibility(gridOptions.showHeaderRow);
+
+  // In pre-Hooks version, we wouldn't do this on first render (grid creation).
+  // May want or need to optimize for that case.
+  grid.setColumns(gridCols);
+  grid.setData(dataView);
+
+  // update sort columns:
+  const vpSortKey = sortKey
+    ? sortKey.map(([columnId, sortAsc]) => ({ columnId, sortAsc }))
+    : [];
+  grid.setSortColumns(vpSortKey);
+  grid.invalidateAllRows();
+  grid.updateRowCount();
+  grid.render();
+  grid.resizeCanvas();
+};
+
+const createGridState = (
+  containerId: string,
+  props: DataGridProps
+): GridState => {
+  const {
+    dataView,
+    showColumnHistograms,
+    histoMap,
+    getColumnFormatter,
+    getColumnCssClassName,
+    pivotColumnDisplayName,
+    showLoadingModal,
+    clipboard,
+    openURL,
+    embedded,
+    isPivoted,
+    showHiddenColumns,
+    displayColumns,
+  } = props;
+
+  const colWidthsMap = getInitialColWidthsMap(getColumnFormatter, dataView!);
+  const slickColMap = mkSlickColMap(
+    dataView!.schema,
+    getColumnFormatter,
+    getColumnCssClassName,
+    pivotColumnDisplayName ?? "",
+    colWidthsMap
+  );
+  const gs = { grid: null, colWidthsMap, slickColMap, containerId };
+
+  const gridCols = getGridCols(
+    gs,
+    isPivoted ?? false,
+    showHiddenColumns,
+    getColumnFormatter,
+    dataView!,
+    displayColumns
+  );
+  gs.grid = createGrid(containerId, gridCols, dataView, props);
+  return gs;
+};
+
+export interface DataGridProps {
+  dataView: PagedDataView | null | undefined;
+  showColumnHistograms?: boolean;
+  histoMap?: reltab.ColumnHistogramMap;
+  getColumnFormatter: (schema: reltab.Schema, cid: string) => CellFormatter;
+  getColumnCssClassName: (schema: reltab.Schema, cid: string) => string | null;
+  pivotColumnDisplayName?: string;
+  isPivoted?: boolean;
+  showHiddenColumns: boolean;
+  displayColumns: string[];
+  showLoadingModal: boolean;
+  clipboard: SimpleClipboard;
+  onViewportChanged?: (top: number, bottom: number) => void;
+  onHistogramBrushRange?: (
+    colId: string,
+    range: [number, number] | null
+  ) => void;
+  onHistogramBrushFilter?: (
+    colId: string,
+    range: [number, number] | null
+  ) => void;
+  sortKey?: [string, boolean][];
+  onSetSortKey?: (sortKey: [string, boolean][]) => void;
+  onGridClick?: (
+    row: number,
+    column: number,
+    dataRow: DataRow,
+    columnId: string,
+    cellVal: any
+  ) => void;
+  onSetColumnOrder?: (displayColumns: string[]) => void;
+  openURL: OpenURLFn;
+  embedded: boolean;
+}
+
+export const DataGrid: React.FunctionComponent<DataGridProps> = (
+  props: DataGridProps
+) => {
+  const {
+    dataView,
+    showColumnHistograms,
+    histoMap,
+    showLoadingModal,
+    clipboard,
+    openURL,
+    embedded,
+  } = props;
+  const containerIdRef = useRef(genContainerId());
+  const [gridState, setGridState] = useState<GridState | null>(null);
+
+  const prevShowColumnHistograms = useRef(showColumnHistograms);
+
+  React.useLayoutEffect(() => {
+    let gs = gridState;
+    // The extra check here for prevShowColumnHistograms is a workaround
+    // for an apparent bug in SlickGrid where it doesn't seem to re-render
+    // correctly when we dynamically change the showHeaderRow option on the grid.
+    if (
+      gs === null ||
+      (prevShowColumnHistograms.current !== showColumnHistograms && histoMap)
+    ) {
+      // log.debug("RawGridPane: creating grid state");
+      gs = createGridState(containerIdRef.current, props);
+      gs.grid.resizeCanvas();
+      setGridState(gs);
+      // log.debug("RawGridPane: done creating grid state");
+      prevShowColumnHistograms.current = showColumnHistograms;
+    }
+    if (dataView != null) {
+      // log.debug("RawGridPane: updating grid");
+      updateGrid(gs, props);
+    } else {
+      // log.debug("RawGridPane: no view change, skipping grid update");
+    }
+  }, [dataView, gridState, showColumnHistograms]);
+
+  const handleGridResize = () => {
+    // TODO: debounce?
+    if (gridState) {
+      gridState.grid.resizeCanvas();
+    }
+  };
+
+  const handleWindowResize = (e: any) => {
+    // console.log("handleWindowResize: ", e);
+    if (gridState) {
+      /*
+      const $container = $(container)
+      console.log('$container: ', $container)
+      const pvh = $.css($container[0], 'height', true)
+      console.log('viewport height before resize:', pvh)
+      */
+      gridState.grid.resizeCanvas();
+      /*
+      console.log('viewport height after resize:', $.css($container[0], 'height', true))
+      console.log('gridPane.handleWindowResize: done with resize and render')
+      */
+    }
+  };
+
+  const lm = showLoadingModal ? <LoadingModal /> : null;
+
+  return (
+    <div className="gridPaneOuter">
+      <div className="gridPaneInner">
+        <ResizeSensor onResize={handleGridResize}>
+          <div
+            id={containerIdRef.current}
+            className="slickgrid-container full-height"
+          />
+        </ResizeSensor>
+      </div>
+      {lm}
+    </div>
+  );
+};

--- a/packages/tadviewer/src/components/GridPane.tsx
+++ b/packages/tadviewer/src/components/GridPane.tsx
@@ -1,15 +1,9 @@
-// for debugging resize handler:
-// import $ from 'jquery'
 import * as React from "react";
-import _, { cloneDeep, CurriedFunction1 } from "lodash";
-
-/* /// <reference path="slickgrid-es6.d.ts"> */
-import * as SlickGrid from "slickgrid-es6";
 import * as reltab from "reltab";
 import * as actions from "../actions";
-import { LoadingModal } from "./LoadingModal";
 import { SimpleClipboard } from "./SimpleClipboard";
-import { PagedDataView } from "../PagedDataView";
+import { DataGridProps, DataGrid } from "./DataGrid";
+import { DataRow, PagedDataView } from "../PagedDataView";
 import { ViewParams } from "../ViewParams";
 import * as util from "../util";
 import * as he from "he";
@@ -17,712 +11,174 @@ import { AppState } from "../AppState";
 import { ViewState } from "../ViewState";
 import { mutableGet, StateRef } from "oneref";
 import { useState, useRef, MutableRefObject } from "react";
+import _ from "lodash";
 import log from "loglevel";
 
-const { Slick } = SlickGrid;
-const { Plugins } = SlickGrid as any;
-const { CellRangeSelector, CellSelectionModel, CellCopyManager, AutoTooltips } =
-  Plugins;
-import { ResizeEntry, ResizeSensor } from "@blueprintjs/core";
 import { ColumnType, NumericColumnHistogramData, Schema } from "reltab";
 import ReactDOM from "react-dom/client";
-import {
-  VictoryAxis,
-  VictoryBar,
-  VictoryBrushContainer,
-  VictoryChart,
-  VictoryTheme,
-} from "victory";
 
 export type OpenURLFn = (url: string) => void;
 
-let divCounter = 0;
-
-const genContainerId = (): string => `epGrid${divCounter++}`;
-
-const baseGridOptions = {
-  multiColumnSort: true,
-  headerRowHeight: 80,
-};
-
-const INDENT_PER_LEVEL = 15; // pixels
-
-const calcIndent = (depth: number): number => INDENT_PER_LEVEL * depth;
-
-/*
- * Formatter for cells in pivot column
- */
-const groupCellFormatter = (
-  row: any,
-  cell: any,
-  value: any,
-  columnDef: any,
-  item: any
-) => {
-  const toggleCssClass = "slick-group-toggle";
-  const toggleExpandedCssClass = "expanded";
-  const toggleCollapsedCssClass = "collapsed";
-  const groupTitleCssClass = "slick-group-title";
-
-  var indentation = calcIndent(item._depth) + "px";
-
-  var pivotStr = item._pivot || "";
-
-  const expandClass = !item._isLeaf
-    ? item._isOpen
-      ? toggleExpandedCssClass
-      : toggleCollapsedCssClass
-    : "";
-  const ret = `
-<span class='${toggleCssClass} ${expandClass}' style='margin-left: ${indentation}'>
-</span>
-<span class='${groupTitleCssClass}' level='${item._depth}'>${pivotStr}</span>`;
-  return ret;
-};
-
-// scan table data to make best effort at initial column widths
-const MINCOLWIDTH = 150;
-const MAXCOLWIDTH = 300;
-
-// TODO: use real font metrics:
-const measureStringWidth = (s: string): number => 8 + 5.5 * s.length;
-const measureHeaderStringWidth = (s: string): number => 24 + 5.5 * s.length;
-
-// get column width for specific column:
-const getColWidth = (
-  viewParams: ViewParams,
-  schema: Schema,
-  dataView: PagedDataView,
-  cnm: string
-) => {
-  let sf: (val: any) => string;
-  if (schema.columnIndex(cnm)) {
-    const cf = viewParams.getColumnFormatter(schema, cnm);
-    sf = (val: any) => cf(val) ?? val.toString();
-  } else {
-    sf = (val: any) => val.toString();
-  }
-  let colWidth;
-  const offset = dataView.getOffset();
-  const limit = offset + dataView.getItemCount();
-  for (var i = offset; i < limit; i++) {
-    var row = dataView.getItem(i);
-    var cellVal = row[cnm];
-    var cellWidth = MINCOLWIDTH;
-    if (cellVal) {
-      cellWidth = measureStringWidth(sf(cellVal));
-    }
-    if (cnm === "_pivot") {
-      cellWidth += calcIndent(row._depth + 2);
-    }
-    colWidth = Math.min(
-      MAXCOLWIDTH,
-      Math.max(colWidth || MINCOLWIDTH, cellWidth)
-    );
-  }
-  const displayName = dataView.schema.displayName(cnm);
-  const headerStrWidth = measureHeaderStringWidth(displayName);
-  colWidth = Math.min(
-    MAXCOLWIDTH,
-    Math.max(colWidth || MINCOLWIDTH, headerStrWidth)
-  );
-  return colWidth;
-};
-
-type ColWidthMap = { [cid: string]: number };
-
-function getInitialColWidthsMap(
-  viewParams: ViewParams,
-  schema: Schema,
-  dataView: PagedDataView
-): ColWidthMap {
-  // let's approximate the column width:
-  var colWidths: ColWidthMap = {};
-  var nRows = dataView.getLength();
-  if (nRows === 0) {
-    return {};
-  }
-  const initRow = dataView.getItem(0);
-  for (let cnm in initRow) {
-    colWidths[cnm] = getColWidth(viewParams, schema, dataView, cnm);
-  }
-
-  return colWidths;
-}
-
-/*
- * Construct map of SlickGrid column descriptors from base schema
- * and column width info
- *
- * Map should contain entries for all column ids
- */
-const mkSlickColMap = (
-  schema: reltab.Schema,
-  viewParams: ViewParams,
-  colWidths: ColWidthMap
-) => {
-  let slickColMap: any = {};
-
-  // hidden columns:
-  slickColMap["_id"] = { id: "_id", field: "_id", name: "_id" };
-  slickColMap["_parentId"] = {
-    id: "_parentId",
-    field: "_parentId",
-    name: "_parentId",
-  };
-  for (let colId of schema.columns) {
-    let cmd = schema.columnMetadata[colId];
-    if (!cmd) {
-      console.error("could not find column metadata for ", colId, schema);
-    }
-    let ci: any = {
-      id: colId,
-      field: colId,
-      cssClass: "",
-      name: "",
-      formatter: null,
-    };
-    if (colId === "_pivot") {
-      const pivotNames = viewParams.vpivots.map((cid) =>
-        schema.displayName(cid)
-      );
-      const leafCid = viewParams.pivotLeafColumn;
-      let leafPivotStr = leafCid ? " > " + schema.displayName(leafCid) : "";
-      const pivotDisplayName =
-        "Pivot: " + pivotNames.join(" > ") + leafPivotStr;
-      ci.cssClass = "pivot-column";
-      ci.name = he.encode(pivotDisplayName);
-      ci.toolTip = pivotDisplayName;
-      ci.formatter = groupCellFormatter;
-    } else {
-      var displayName = cmd.displayName || colId;
-      ci.name = he.encode(displayName);
-      ci.toolTip = he.encode(displayName);
-      ci.sortable = true;
-      const ff = viewParams.getColumnFormatter(schema, colId);
-      const cellClass = viewParams.getColumnClassName(schema, colId);
-      if (cellClass != null) {
-        ci.cssClass = cellClass;
-      }
-      ci.formatter = (
-        row: any,
-        cell: any,
-        value: any,
-        columnDef: any,
-        item: any
-      ) => (ff as any)(value);
-    }
-    ci.width = colWidths[colId];
-    slickColMap[colId] = ci;
-  }
-  return slickColMap;
-};
-
-interface NumericColumnHistogramProps {
-  histData: NumericColumnHistogramData;
-  colType: ColumnType;
-  stateRef: StateRef<AppState>;
-}
-
-// gross hack to round to two decimal places:
-function round(value: number, decimals: number): number {
-  return Number(
-    Math.round(Number(value.toString() + "e" + decimals.toString())) +
-      "e-" +
-      decimals
-  );
-}
-const NumericColumnHistogram = ({
-  stateRef,
-  colType,
-  histData,
-}: NumericColumnHistogramProps) => {
-  const {
-    colId,
-    binWidth,
-    niceMinVal,
-    niceMaxVal,
-    binData,
-    brushMinVal,
-    brushMaxVal,
-  } = histData;
-  const chartData = binData.map((count: number, binIndex: number) => ({
-    binMid: niceMinVal + (binIndex + 0.5) * binWidth,
-    count,
-  }));
-  const fmtOpts = {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-    useGrouping: true,
-  };
-
-  const handleBrush = (brushInfo: any) => {
-    actions.setHistogramBrushRange(colId, brushInfo.x, stateRef);
-  };
-  const handleBrushEnd = (brushInfo: any) => {
-    let [minVal, maxVal] = brushInfo.x;
-    if (colType.kind === "integer") {
-      minVal = Math.round(minVal);
-      maxVal = Math.round(maxVal);
-    } else {
-      minVal = round(minVal, 2);
-      maxVal = round(maxVal, 2);
-    }
-    actions.setHistogramBrushFilter(colId, [minVal, maxVal], stateRef);
-  };
-
-  return (
-    <VictoryChart
-      padding={60}
-      domain={{ x: [niceMinVal, niceMaxVal + binWidth * 2] }}
-      containerComponent={
-        <VictoryBrushContainer
-          responsive={true}
-          brushDimension="x"
-          brushDomain={{ x: [brushMinVal, brushMaxVal] }}
-          onBrushDomainChange={handleBrush}
-          onBrushDomainChangeEnd={handleBrushEnd}
-        />
-      }
-    >
-      <VictoryAxis
-        tickValues={[niceMinVal, niceMaxVal]}
-        tickFormat={(tick: number) => tick.toLocaleString(undefined, fmtOpts)}
-        style={{
-          axis: { stroke: "none" },
-          tickLabels: { fontSize: 40 },
-        }}
-      />
-      <VictoryAxis
-        dependentAxis
-        tickCount={2}
-        style={{
-          axis: { stroke: "none" },
-          tickLabels: { fontSize: 40 },
-        }}
-      />
-      <VictoryBar
-        style={{ data: { fill: "rgb(25, 118, 210)" } }}
-        data={chartData}
-        x="binMid"
-        y="count"
-      />
-    </VictoryChart>
-  );
-};
-
-/**
- * React component wrapper around SlickGrid
- *
- */
 export interface GridPaneProps {
   appState: AppState;
   viewState: ViewState;
   stateRef: StateRef<AppState>;
-  onSlickGridCreated: (grid: any) => void;
   clipboard: SimpleClipboard;
   openURL: OpenURLFn;
   embedded: boolean;
 }
 
-const getGridOptions = (viewState: ViewState) => {
-  const { queryView } = viewState;
-  const histoCount = queryView?.histoMap
-    ? Object.keys(queryView.histoMap).length
-    : 0;
-
-  const showHeaderRow =
-    viewState.viewParams.showColumnHistograms && histoCount > 0;
-  const gridOptions = {
-    ...baseGridOptions,
-    showHeaderRow,
-  };
-  return gridOptions;
-};
-
-const getGridOptionsFromStateRef = (stateRef: StateRef<AppState>) => {
-  const appState = mutableGet(stateRef);
-
-  return getGridOptions(appState.viewState);
-};
-
-// escape tabs by placing string in quotes
-function escapeTabs(cellData: any): any {
-  if (typeof cellData === "string" && cellData.indexOf("\t") >= 0) {
-    return '"' + cellData.replace(/"/g, '""') + '"';
-  }
-  return cellData;
-}
-
-/* Create grid from the specified set of columns */
-const createGrid = (
-  stateRef: StateRef<AppState>,
-  containerId: string,
-  viewStateRef: MutableRefObject<ViewState>,
-  columns: any,
-  data: any,
-  clipboard: SimpleClipboard,
-  openURL: (url: string) => void,
-  embedded: boolean
-) => {
-  const gridOptions = getGridOptionsFromStateRef(stateRef);
-  let grid = new Slick.Grid(`#${containerId}`, data, columns, gridOptions);
-
-  const selectionModel = new CellSelectionModel();
-  grid.setSelectionModel(selectionModel);
-  selectionModel.onSelectedRangesChanged.subscribe((e: any, args: any) => {
-    // TODO: could store this in app state and show some
-    // stats about selected range
-  });
-
-  const copyManager = new CellCopyManager();
-  grid.registerPlugin(copyManager);
-  grid.registerPlugin(new AutoTooltips({ enableForCells: true }));
-
-  const copySelectedRange = async (range: any) => {
-    let copyRowStrings: string[] = [];
-    const gridCols = grid.getColumns();
-    const gridData = grid.getData();
-    for (let row = range.fromRow; row <= range.toRow; row++) {
-      const rowData = gridData.getItem(row);
-      const copyRow = [];
-      for (let col = range.fromCell; col <= range.toCell; col++) {
-        const cid = gridCols[col].id;
-        copyRow.push(escapeTabs(rowData[cid]));
-      }
-      copyRowStrings.push(copyRow.join("\t"));
-    }
-    const copyData = copyRowStrings.join("\r\n") + "\r\n";
-    clipboard.writeText(copyData);
-  };
-
-  copyManager.onCopyCells.subscribe(async (e: any, args: any) => {
-    const range = args.ranges[0];
-    copySelectedRange(range);
-  });
-
-  // gross hack, but makes copy menu item work in Electron:
-  if (!embedded) {
-    document.addEventListener("copy", function (e) {
-      const ranges = grid.getSelectionModel().getSelectedRanges();
-      if (ranges && ranges.length != 0) {
-        copySelectedRange(ranges[0]);
-      }
-    });
-  }
-  const rangeSelector = new CellRangeSelector();
-
-  grid.registerPlugin(rangeSelector);
-
-  const updateViewportDebounced = _.debounce(() => {
-    const vp = grid.getViewport();
-    actions.updateViewport(vp.top, vp.bottom, stateRef);
-  }, 100);
-
-  grid.onViewportChanged.subscribe((e: any, args: any) => {
-    updateViewportDebounced();
-  });
-
-  grid.onHeaderRowCellRendered.subscribe((e: any, { node, column }: any) => {
-    const appState = mutableGet(stateRef);
-    const viewState = appState.viewState;
-    const { queryView } = viewState;
-    console.log("onHeaderRowCellRendered: ", column);
-    if (queryView && queryView.histoMap && queryView.histoMap[column.id]) {
-      const histo = queryView.histoMap[column.id];
-      const colType = viewState.baseSchema.columnType(column.id);
-      const root = ReactDOM.createRoot(node);
-      root.render(
-        <NumericColumnHistogram
-          histData={histo}
-          colType={colType}
-          stateRef={stateRef}
-        />
-      );
-      node.classList.add("slick-editable");
-    } else {
-      console.log("*** no histo for column: ", column.id);
-    }
-  });
-
-  grid.onSort.subscribe((e: any, args: any) => {
-    // console.log("grid onSort: ", args);
-    // convert back from slickGrid format: */
-    const sortKey = args.sortCols.map((sc: any) => [
-      sc.sortCol.field,
-      sc.sortAsc,
-    ]);
-    actions.setSortKey(sortKey, stateRef);
-  });
-
-  const onGridClick = (e: any, args: any) => {
-    // log.info("onGridClick: ", e, args);
-    const viewState = viewStateRef.current;
-    const viewParams = viewState.viewParams;
-    const columns = grid.getColumns();
-    const col = columns[args.cell];
-    // log.info("onGridClick: column: ", col);
-    var item = grid.getDataItem(args.row);
-    // log.info("onGridClick: item: ", item);
-
-    if (col.id === "_pivot") {
-      if (item._isLeaf) {
-        return;
-      }
-      const vpivots = viewParams.vpivots;
-      const depth = item._depth;
-      let path = [];
-      for (let i = 0; i < vpivots.length && i < depth; i++) {
-        let pathItem = item["_path" + i];
-        path.push(item["_path" + i]);
-      }
-      // log.info("onGridClick: path: ", path);
-      if (item._isOpen) {
-        actions.closePath(path, stateRef);
-      } else {
-        actions.openPath(path, stateRef);
-      }
-    } else {
-      const dataView: PagedDataView = grid.getData();
-      if (dataView.schema.columnIndex(col.id)) {
-        const ch = viewParams.getClickHandler(dataView.schema, col.id);
-        ch({ openURL }, args.row, args.cell, item[col.id]);
-      }
-    }
-  };
-
-  grid.onClick.subscribe(onGridClick);
-
-  grid.onColumnsReordered.subscribe((e: any, args: any) => {
-    const cols = grid.getColumns();
-    const displayColIds = cols
-      .map((c: any) => c.field)
-      .filter((cid: any) => cid[0] !== "_");
-    actions.setColumnOrder(displayColIds, stateRef);
-  });
-
-  // load the first page
-  grid.onViewportChanged.notify();
-
-  return grid;
-};
-
-const isPivoted = (viewState: ViewState) => {
-  const viewParams = viewState.viewParams;
-  return viewParams.vpivots.length > 0;
-};
-
-interface GridState {
-  grid: any;
-  colWidthsMap: ColWidthMap | null;
-  slickColMap: any;
-  containerId: string;
-}
-
-const updateColWidth = (
-  gs: GridState,
-  viewParams: ViewParams,
-  schema: Schema,
-  dataView: PagedDataView,
-  colId: string
-) => {
-  const colWidth = getColWidth(viewParams, schema, dataView, colId);
-  gs.colWidthsMap![colId] = colWidth;
-  gs.slickColMap[colId].width = colWidth;
-};
-
-// Get grid columns based on current column visibility settings:
-const getGridCols = (gs: GridState, viewState: ViewState) => {
-  const { viewParams, dataView } = viewState;
-  const showHiddenCols = viewParams.showHiddenCols;
-  const displayCols = viewParams.displayColumns;
-
-  let gridCols = displayCols.map((cid) => gs.slickColMap[cid]);
-  if (isPivoted(viewState)) {
-    updateColWidth(gs, viewParams, dataView!.schema, dataView!, "_pivot");
-    let pivotCol = gs.slickColMap["_pivot"];
-    gridCols.unshift(pivotCol);
-  }
-  if (showHiddenCols) {
-    const hiddenColIds = _.difference(
-      _.keys(gs.slickColMap),
-      gridCols.map((gc) => gc.field)
-    );
-    const hiddenCols = hiddenColIds.map((cid) => gs.slickColMap[cid]);
-    gridCols = gridCols.concat(hiddenCols);
-  }
-  return gridCols;
-};
-
-/*
- * update grid from dataView
- */
-const updateGrid = (gs: GridState, viewState: ViewState) => {
-  const { viewParams, dataView } = viewState;
-  if (dataView == null) return;
-
-  gs.slickColMap = mkSlickColMap(dataView.schema, viewParams, gs.colWidthsMap!);
-  const gridCols = getGridCols(gs, viewState);
-
-  const grid = gs.grid;
-
-  const gridOptions = getGridOptions(viewState);
-  // console.log("updateGrid: gridOptions: ", gridOptions);
-
-  grid.setOptions(gridOptions);
-  grid.setHeaderRowVisibility(gridOptions.showHeaderRow);
-
-  // In pre-Hooks version, we wouldn't do this on first render (grid creation).
-  // May want or need to optimize for that case.
-  grid.setColumns(gridCols);
-  grid.setData(dataView);
-
-  // update sort columns:
-  const vpSortKey = viewParams.sortKey.map(([columnId, sortAsc]) => ({
-    columnId,
-    sortAsc,
-  }));
-  grid.setSortColumns(vpSortKey);
-  grid.invalidateAllRows();
-  grid.updateRowCount();
-  grid.render();
-  grid.resizeCanvas();
-};
-
-const createGridState = (
-  stateRef: StateRef<AppState>,
-  viewStateRef: MutableRefObject<ViewState>,
-  containerId: string,
-  clipboard: SimpleClipboard,
-  openURL: (url: string) => void,
-  embedded: boolean
-): GridState => {
-  const { viewParams, dataView, baseSchema } = viewStateRef.current;
-  const colWidthsMap = getInitialColWidthsMap(
-    viewParams,
-    dataView!.schema,
-    dataView!
-  );
-  const slickColMap = mkSlickColMap(dataView!.schema, viewParams, colWidthsMap);
-  const gs = { grid: null, colWidthsMap, slickColMap, containerId };
-
-  const gridCols = getGridCols(gs, viewStateRef.current);
-  gs.grid = createGrid(
-    stateRef,
-    containerId,
-    viewStateRef,
-    gridCols,
-    dataView,
-    clipboard,
-    openURL,
-    embedded
-  );
-  return gs;
-};
-
-const RawGridPane: React.FunctionComponent<GridPaneProps> = ({
+// GridPaneInternal the un-memoized GridPane component
+const GridPaneInternal: React.FunctionComponent<GridPaneProps> = ({
   appState,
   viewState,
   stateRef,
-  onSlickGridCreated,
   clipboard,
   openURL,
   embedded,
 }) => {
-  const containerIdRef = useRef(genContainerId());
-  const [gridState, setGridState] = useState<GridState | null>(null);
   const viewStateRef = useRef<ViewState>(viewState);
-
-  const prevShowColumnHistograms = useRef(
-    viewState.viewParams.showColumnHistograms
-  );
 
   viewStateRef.current = viewState;
 
-  const dataView = viewState.dataView;
-
-  const { showColumnHistograms } = viewState.viewParams;
-
-  // log.debug("RawGridPane: ", appState.toJS(), viewState.toJS());
-
-  React.useLayoutEffect(() => {
-    let gs = gridState;
-    // The extra check here for prevShowColumnHistograms is a workaround
-    // for an apparent bug in SlickGrid where it doesn't seem to re-render
-    // correctly when we dynamically change the showHeaderRow option on the grid.
-    const histoMap = viewState.queryView?.histoMap;
-    if (
-      gs === null ||
-      (prevShowColumnHistograms.current !== showColumnHistograms && histoMap)
-    ) {
-      // log.debug("RawGridPane: creating grid state");
-      gs = createGridState(
-        stateRef,
-        viewStateRef,
-        containerIdRef.current,
-        clipboard,
-        openURL,
-        embedded
-      );
-      if (onSlickGridCreated) {
-        onSlickGridCreated(gs.grid);
-      }
-      gs.grid.resizeCanvas();
-      setGridState(gs);
-      // log.debug("RawGridPane: done creating grid state");
-      prevShowColumnHistograms.current = showColumnHistograms;
-    }
-    if (dataView != null) {
-      // log.debug("RawGridPane: updating grid");
-      updateGrid(gs, viewStateRef.current);
-    } else {
-      // log.debug("RawGridPane: no view change, skipping grid update");
-    }
-  }, [dataView, gridState, showColumnHistograms]);
-
-  const handleGridResize = (entries: ResizeEntry[]) => {
-    // TODO: debounce?
-    if (gridState) {
-      gridState.grid.resizeCanvas();
-    }
-  };
-
-  const handleWindowResize = (e: any) => {
-    // console.log("handleWindowResize: ", e);
-    if (gridState) {
-      /*
-      const $container = $(container)
-      console.log('$container: ', $container)
-      const pvh = $.css($container[0], 'height', true)
-      console.log('viewport height before resize:', pvh)
-      */
-      gridState.grid.resizeCanvas();
-      /*
-      console.log('viewport height after resize:', $.css($container[0], 'height', true))
-      console.log('gridPane.handleWindowResize: done with resize and render')
-      */
-    }
-  };
-
-  const lt = viewState.loadingTimer;
   // Only show loading modal if we've been loading more than 500 ms
-  const lm = lt.running && lt.elapsed > 500 ? <LoadingModal /> : null;
+  const lt = viewState.loadingTimer;
+  const showLoadingModal = lt.running && lt.elapsed > 500;
 
-  return (
-    <div className="gridPaneOuter">
-      <div className="gridPaneInner">
-        <ResizeSensor onResize={handleGridResize}>
-          <div
-            id={containerIdRef.current}
-            className="slickgrid-container full-height"
-          />
-        </ResizeSensor>
-      </div>
-      {lm}
-    </div>
+  const { dataView, viewParams } = viewState;
+  const { showColumnHistograms } = viewState.viewParams;
+  const histoMap = viewState.queryView?.histoMap;
+
+  const getColumnFormatter = React.useCallback(
+    (schema: reltab.Schema, cid: string) =>
+      viewState.viewParams.getColumnFormatter(schema, cid),
+    [viewState.viewParams]
   );
+
+  const getColumnCssClassName = React.useCallback(
+    (schema: reltab.Schema, cid: string) =>
+      viewState.viewParams.getColumnClassName(schema, cid),
+    [viewState.viewParams]
+  );
+
+  let pivotColumnDisplayName = "";
+  if (dataView) {
+    const { schema } = dataView;
+    const pivotNames = viewParams.vpivots.map((cid) => schema.displayName(cid));
+    const leafCid = viewParams.pivotLeafColumn;
+    let leafPivotStr = leafCid ? " > " + schema.displayName(leafCid) : "";
+    pivotColumnDisplayName = "Pivot: " + pivotNames.join(" > ") + leafPivotStr;
+  }
+
+  const showHiddenColumns = viewParams.showHiddenCols;
+  const displayColumns = viewParams.displayColumns;
+
+  const onViewportChanged = React.useCallback(
+    (top: number, bottom: number) => {
+      actions.updateViewport(top, bottom, stateRef);
+    },
+    [stateRef]
+  );
+
+  const onHistogramBrushRange = React.useCallback(
+    (cid: string, range: [number, number] | null) => {
+      actions.setHistogramBrushRange(cid, range, stateRef);
+    },
+    [stateRef]
+  );
+
+  const onHistogramBrushFilter = React.useCallback(
+    (cid: string, range: [number, number] | null) => {
+      actions.setHistogramBrushFilter(cid, range, stateRef);
+    },
+    [stateRef]
+  );
+
+  const onSetSortKey = React.useCallback(
+    (sortKey: [string, boolean][]) => {
+      actions.setSortKey(sortKey, stateRef);
+    },
+    [stateRef]
+  );
+  const sortKey = viewParams.sortKey;
+
+  const onGridClick = React.useCallback(
+    (
+      row: number,
+      column: number,
+      item: DataRow,
+      columnId: string,
+      cellVal: any
+    ) => {
+      const appState = mutableGet(stateRef);
+      const { viewState } = appState;
+      const { viewParams, dataView } = viewState;
+      // log.info("onGridClick: item: ", item);
+
+      if (columnId === "_pivot") {
+        if (item._isLeaf) {
+          return;
+        }
+        const vpivots = viewParams.vpivots;
+        const depth = item._depth;
+        let path: string[] = [];
+        for (let i = 0; i < vpivots.length && i < depth; i++) {
+          let pathItem = item["_path" + i];
+          path.push(item["_path" + i] as string);
+        }
+        // log.info("onGridClick: path: ", path);
+        if (item._isOpen) {
+          actions.closePath(path, stateRef);
+        } else {
+          actions.openPath(path, stateRef);
+        }
+      } else {
+        if (dataView?.schema.columnIndex(columnId)) {
+          const ch = viewParams.getClickHandler(dataView.schema, columnId);
+          ch({ openURL }, row, column, cellVal);
+        }
+      }
+    },
+    [stateRef]
+  );
+
+  const onSetColumnOrder = React.useCallback(
+    (columnIds: string[]) => {
+      actions.setColumnOrder(columnIds, stateRef);
+    },
+    [stateRef]
+  );
+
+  const isPivoted = viewParams.vpivots.length > 0;
+
+  const dataGridProps: DataGridProps = {
+    dataView,
+    showColumnHistograms,
+    histoMap,
+    getColumnFormatter,
+    getColumnCssClassName,
+    pivotColumnDisplayName,
+    showLoadingModal,
+    showHiddenColumns,
+    displayColumns,
+    onViewportChanged,
+    onHistogramBrushRange,
+    onHistogramBrushFilter,
+    onSetSortKey,
+    onGridClick,
+    onSetColumnOrder,
+    sortKey,
+    isPivoted,
+    clipboard,
+    openURL,
+    embedded,
+  };
+
+  return <DataGrid {...dataGridProps} />;
 };
 
+// TODO: It might be better to move this memoization down a level into DataGrid,
+// but we'll leave it here for now
 const gridPanePropsEqual = (oldProps: any, nextProps: any): boolean => {
   const viewState = oldProps.viewState;
   const nextViewState = nextProps.viewState;
@@ -739,4 +195,4 @@ const gridPanePropsEqual = (oldProps: any, nextProps: any): boolean => {
   return ret;
 };
 
-export const GridPane = React.memo(RawGridPane, gridPanePropsEqual);
+export const GridPane = React.memo(GridPaneInternal, gridPanePropsEqual);


### PR DESCRIPTION
GridPane had become a bit unwieldy because it had a mixture of Tad pivot table logic and numerous SlickGrid details.

This PR breaks up GridPane into two parts:

- A `DataGrid` React component for a flat, virtualized grid that hides all SlickGrid implementation details and has event callbacks for all of the grid events needed by Tad.
- A `GridPane` that uses `DataGrid` to provide the Tad pivot table. 