### PR TITLE
adds an onFilter prop to TadViewerPane

### DIFF
--- a/packages/tadviewer/src/components/AppPane.tsx
+++ b/packages/tadviewer/src/components/AppPane.tsx
@@ -21,12 +21,7 @@ import * as oneref from "oneref";
 import { useState } from "react";
 import { Activity } from "./defs";
 import { mutableGet, StateRef } from "oneref";
-import {
-  DataSourcePath,
-  DuckDBDialect,
-  ReltabConnection,
-  resolvePath,
-} from "reltab";
+import { DataSourcePath, ReltabConnection, resolvePath } from "reltab";
 import { useDeepCompareEffect } from "use-deep-compare";
 import { Timer } from "../Timer";
 import { SimpleClipboard } from "./SimpleClipboard";
@@ -198,8 +193,8 @@ export const AppPane: React.FunctionComponent<AppPaneProps> = ({
   showDataSources: rawShowDataSources,
   openURL,
   embedded,
-  rightFooterSlot = undefined,
-  onFilter = undefined,
+  rightFooterSlot,
+  onFilter,
 }: AppPaneProps) => {
   const { activity } = appState;
   const dataSourceExpanded = activity === "DataSource";

--- a/packages/tadviewer/src/components/AppPane.tsx
+++ b/packages/tadviewer/src/components/AppPane.tsx
@@ -21,11 +21,17 @@ import * as oneref from "oneref";
 import { useState } from "react";
 import { Activity } from "./defs";
 import { mutableGet, StateRef } from "oneref";
-import { DataSourcePath, ReltabConnection, resolvePath } from "reltab";
+import {
+  DataSourcePath,
+  DuckDBDialect,
+  ReltabConnection,
+  resolvePath,
+} from "reltab";
 import { useDeepCompareEffect } from "use-deep-compare";
 import { Timer } from "../Timer";
 import { SimpleClipboard } from "./SimpleClipboard";
 import { createDragDropManager } from "dnd-core";
+import { type FilterExp } from "reltab";
 /**
  * top level application pane
  */
@@ -42,6 +48,7 @@ export interface AppPaneBaseProps {
   clipboard: SimpleClipboard;
   embedded: boolean;
   rightFooterSlot?: JSX.Element;
+  onFilter?: (filterExp: FilterExp) => void;
 }
 
 export type AppPaneProps = AppPaneBaseProps & oneref.StateRefProps<AppState>;
@@ -192,6 +199,7 @@ export const AppPane: React.FunctionComponent<AppPaneProps> = ({
   openURL,
   embedded,
   rightFooterSlot = undefined,
+  onFilter = undefined,
 }: AppPaneProps) => {
   const { activity } = appState;
   const dataSourceExpanded = activity === "DataSource";
@@ -254,6 +262,7 @@ export const AppPane: React.FunctionComponent<AppPaneProps> = ({
           appState={appState}
           stateRef={stateRef}
           rightFooterSlot={rightFooterSlot}
+          onFilter={onFilter}
         />
       </div>
     );

--- a/packages/tadviewer/src/components/Footer.tsx
+++ b/packages/tadviewer/src/components/Footer.tsx
@@ -11,13 +11,14 @@ import { getDefaultDialect } from "reltab";
 export interface FooterProps {
   appState: AppState;
   stateRef: StateRef<AppState>;
+  onFilter?: (filterExp: reltab.FilterExp) => void;
   rightFooterSlot?: JSX.Element;
 }
 
 export const Footer: React.FunctionComponent<FooterProps> = (
   props: FooterProps
 ) => {
-  const { appState, stateRef, rightFooterSlot = undefined } = props;
+  const { appState, stateRef, rightFooterSlot = undefined, onFilter } = props;
   const [expanded, setExpanded] = useState(false);
   const [dirty, setDirty] = useState(false);
   const [prevFilter, setPrevFilter] = useState<reltab.FilterExp | null>(null);
@@ -54,6 +55,7 @@ export const Footer: React.FunctionComponent<FooterProps> = (
 
   const handleFilterApply = (filterExp: reltab.FilterExp) => {
     actions.setFilter(filterExp, stateRef);
+    onFilter?.(filterExp);
   };
 
   const handleFilterDone = () => {

--- a/packages/tadviewer/src/components/TadViewerPane.tsx
+++ b/packages/tadviewer/src/components/TadViewerPane.tsx
@@ -82,8 +82,8 @@ export function TadViewerPane({
   setLoadingCallback,
   showRecordCount,
   showColumnHistograms,
-  rightFooterSlot = undefined,
-  onFilter = undefined,
+  rightFooterSlot,
+  onFilter,
 }: TadViewerPaneProps): JSX.Element | null {
   const [appStateRef, setAppStateRef] = useState<StateRef<AppState> | null>(
     null

--- a/packages/tadviewer/src/components/TadViewerPane.tsx
+++ b/packages/tadviewer/src/components/TadViewerPane.tsx
@@ -8,6 +8,7 @@ import { useMemo, useRef, useState } from "react";
 import {
   DataSourceConnection,
   DataSourcePath,
+  FilterExp,
   LocalReltabConnection,
 } from "reltab";
 import { initAppState } from "../actions";
@@ -20,6 +21,7 @@ interface TadViewerPaneInnerProps {
   stateRef: StateRef<AppState>;
   baseQuery: string;
   rightFooterSlot?: JSX.Element;
+  onFilter?: (filterExp: FilterExp) => void;
 }
 
 const newWindowFromDSPath = (
@@ -34,6 +36,7 @@ function TadViewerPaneInner({
   stateRef,
   baseQuery,
   rightFooterSlot = undefined,
+  onFilter = undefined,
 }: TadViewerPaneInnerProps) {
   const viewerPane = useRef<JSX.Element | null>(null);
 
@@ -54,6 +57,7 @@ function TadViewerPaneInner({
         showDataSources={false}
         embedded={true}
         rightFooterSlot={rightFooterSlot}
+        onFilter={onFilter}
       />
     );
   }
@@ -68,6 +72,7 @@ export interface TadViewerPaneProps {
   showRecordCount: boolean;
   showColumnHistograms: boolean;
   rightFooterSlot?: JSX.Element;
+  onFilter?: (filterExp: FilterExp) => void;
 }
 
 export function TadViewerPane({
@@ -78,6 +83,7 @@ export function TadViewerPane({
   showRecordCount,
   showColumnHistograms,
   rightFooterSlot = undefined,
+  onFilter = undefined,
 }: TadViewerPaneProps): JSX.Element | null {
   const [appStateRef, setAppStateRef] = useState<StateRef<AppState> | null>(
     null
@@ -149,6 +155,7 @@ export function TadViewerPane({
         baseQuery={baseSqlQuery}
         stateRef={appStateRef}
         rightFooterSlot={rightFooterSlot}
+        onFilter={onFilter}
       />
     );
   }


### PR DESCRIPTION
This PR adds an `onFilter` prop to `TadViewerPane`, which will run when the filter expression controls in `Footer.tsx` change. This is to enable applications using the Tad interface to have access to the reltab `FilterExp` instance.

This has been smoketested to confirm that it does not have an effect on the standalone electron app.