### PR TITLE
chore(tadviewer): pin use-deep-compare pkg version

### DIFF
--- a/packages/tadviewer/package.json
+++ b/packages/tadviewer/package.json
@@ -39,7 +39,7 @@
     "slickgrid-es6": "^3.0.3",
     "url-loader": "^4.1.1",
     "url-regex": "5.0.0",
-    "use-deep-compare": "^1.1.0",
+    "use-deep-compare": "1.1.0",
     "victory": "^36.6.10"
   },
   "devDependencies": {


### PR DESCRIPTION
The newly published package of `use-deep-compare` 1.2.0 seems to break `tadviewer` from building successfully. 
So in this commit, we are choring into pinning a specific pkg version.

Ref: https://www.npmjs.com/package/use-deep-compare/v/1.2.0

The next step should consider a proper path of upgrading this library and/or when needed.