### PR TITLE
Pins `use-deep-compare` in tadviewer to 1.1.0

### DIFF
--- a/packages/tadviewer/package.json
+++ b/packages/tadviewer/package.json
@@ -39,7 +39,7 @@
     "slickgrid-es6": "^3.0.3",
     "url-loader": "^4.1.1",
     "url-regex": "5.0.0",
-    "use-deep-compare": "^1.1.0",
+    "use-deep-compare": "1.1.0",
     "victory": "^36.6.10"
   },
   "devDependencies": {


### PR DESCRIPTION
1.2.0 is causing breakage in builds using tadviewer.