### PR TITLE
Add Parquet export

### DIFF
--- a/packages/tad-app/app/appMenu.ts
+++ b/packages/tad-app/app/appMenu.ts
@@ -67,6 +67,20 @@ export const createMenu = () => {
       },
     },
     {
+      label: "Export...",
+      click: (
+        item: MenuItem,
+        focusedWindow: BrowserWindow | undefined,
+        event: KeyboardEvent
+      ) => {
+        if (focusedWindow) {
+          appWindow.beginExport(focusedWindow);
+        }
+      },
+    },
+
+    /*
+    {
       label: "Export Filtered CSV...",
       click: (
         item: MenuItem,
@@ -78,6 +92,7 @@ export const createMenu = () => {
         }
       },
     },
+*/
   ];
 
   if (!isDarwin) {

--- a/packages/tad-app/app/appWindow.ts
+++ b/packages/tad-app/app/appWindow.ts
@@ -378,7 +378,7 @@ ipcMain.on("export-file", async (event: IpcMainEvent, exportFileReq: any) => {
   if (!win) {
     return;
   }
-  const { exportFormat, exportPath } = exportFileReq;
+  const { exportFormat, exportPath, parquetExportOptions } = exportFileReq;
   const queryStr: string = await getFilterQuery(win);
   const req = reltab.deserializeQueryReq(queryStr);
   const { query, filterRowCount } = req;
@@ -387,7 +387,8 @@ ipcMain.on("export-file", async (event: IpcMainEvent, exportFileReq: any) => {
     exportFormat,
     exportPath,
     filterRowCount,
-    query
+    query,
+    parquetExportOptions
   );
 });
 
@@ -400,48 +401,4 @@ export const beginExport = async (win: BrowserWindow) => {
   const req = reltab.deserializeQueryReq(queryStr);
   const { query, filterRowCount } = req;
   await fileExport.openExportBeginDialog(win, filterRowCount, query);
-  /*
-  let saveFilename = null;
-  saveFilename = dialog.showSaveDialogSync(win, {
-    title: "Export Filtered CSV",
-    filters: [
-      {
-        name: "CSV Files",
-        extensions: ["csv"],
-      },
-    ],
-  });
-
-  if (!saveFilename) {
-    // user cancelled save as...
-    return;
-  }
-
-  await fileExport.exportAs(win, saveFilename, filterRowCount, query);
-  */
 };
-
-/*
-export const exportFiltered = async (win: BrowserWindow) => {
-  const queryStr: string = await getFilterQuery(win);
-  const req = reltab.deserializeQueryReq(queryStr);
-  const { query, filterRowCount } = req;
-  let saveFilename = null;
-  saveFilename = dialog.showSaveDialogSync(win, {
-    title: "Export Filtered CSV",
-    filters: [
-      {
-        name: "CSV Files",
-        extensions: ["csv"],
-      },
-    ],
-  });
-
-  if (!saveFilename) {
-    // user cancelled save as...
-    return;
-  }
-
-  await csvexport.exportAs(win, saveFilename, filterRowCount, query);
-};
-*/

--- a/packages/tad-app/app/appWindow.ts
+++ b/packages/tad-app/app/appWindow.ts
@@ -357,19 +357,39 @@ const browseExportPath = async (
   if (!win) {
     return;
   }
+  const { exportFormat } = browseInfo;
+
+  const fmtFilter = {
+    name: `${exportFormat} files`,
+    extensions: [exportFormat],
+  };
+
   const exportPath = dialog.showSaveDialogSync(win, {
-    title: "Export Filtered CSV",
-    filters: [
-      {
-        name: "CSV Files",
-        extensions: ["csv"],
-      },
-    ],
+    title: "Export Filtered Data",
+    filters: [fmtFilter],
   });
   win.webContents.send("set-export-path", { exportPath });
 };
 
 ipcMain.on("browse-export-path", browseExportPath);
+
+ipcMain.on("export-file", async (event: IpcMainEvent, exportFileReq: any) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!win) {
+    return;
+  }
+  const { exportFormat, exportPath } = exportFileReq;
+  const queryStr: string = await getFilterQuery(win);
+  const req = reltab.deserializeQueryReq(queryStr);
+  const { query, filterRowCount } = req;
+  await fileExport.exportFile(
+    win,
+    exportFormat,
+    exportPath,
+    filterRowCount,
+    query
+  );
+});
 
 /*
  * Begin the export dialog to export a filtered or unfiltered dataset as

--- a/packages/tad-app/app/fileExport.ts
+++ b/packages/tad-app/app/fileExport.ts
@@ -3,6 +3,7 @@ import * as csv from "fast-csv";
 import * as fs from "fs";
 import { BrowserWindow } from "electron";
 import { DbDataSource } from "reltab";
+import { ExportFormat } from "tadviewer";
 
 export const openExportBeginDialog = async (
   win: BrowserWindow,
@@ -15,17 +16,49 @@ export const openExportBeginDialog = async (
   });
 };
 
+export const exportFile = async (
+  win: BrowserWindow,
+  exportFormat: ExportFormat,
+  exportPath: string,
+  filterRowCount: number,
+  query: reltab.QueryExp
+) => {
+  console.log(
+    "*** exportFile: ",
+    exportFormat,
+    exportPath,
+    filterRowCount,
+    query
+  );
+  if (exportFormat === "csv") {
+    return exportCSV(win, exportPath, filterRowCount, query);
+  } else if (exportFormat === "parquet") {
+    return exportParquet(win, exportPath, filterRowCount, query);
+  } else {
+    console.error("Unsupported export format: ", exportFormat);
+  }
+};
+
+export const exportParquet = async (
+  win: BrowserWindow,
+  saveFilename: string,
+  filterRowCount: number,
+  query: reltab.QueryExp
+) => {
+  console.log("*** exportParquet: ", saveFilename, filterRowCount, query);
+};
+
 // maximum number of items outstanding before pause and commit:
 // Some studies of sqlite found this number about optimal
 const BATCHSIZE = 10000;
-export const exportAs = async (
+export const exportCSV = async (
   win: BrowserWindow,
   saveFilename: string,
   filterRowCount: number,
   query: reltab.QueryExp
 ) => {
   let exportPercent = 0;
-  win.webContents.send("open-export-dialog", {
+  win.webContents.send("open-export-progress-dialog", {
     openState: true,
     saveFilename,
     exportPercent,

--- a/packages/tad-app/app/fileExport.ts
+++ b/packages/tad-app/app/fileExport.ts
@@ -4,6 +4,17 @@ import * as fs from "fs";
 import { BrowserWindow } from "electron";
 import { DbDataSource } from "reltab";
 
+export const openExportBeginDialog = async (
+  win: BrowserWindow,
+  filterRowCount: number,
+  query: reltab.QueryExp
+) => {
+  win.webContents.send("open-export-begin-dialog", {
+    openState: true,
+    filterRowCount,
+  });
+};
+
 // maximum number of items outstanding before pause and commit:
 // Some studies of sqlite found this number about optimal
 const BATCHSIZE = 10000;

--- a/packages/tad-app/app/fileExport.ts
+++ b/packages/tad-app/app/fileExport.ts
@@ -3,7 +3,7 @@ import * as csv from "fast-csv";
 import * as fs from "fs";
 import { BrowserWindow, dialog } from "electron";
 import { DbDataSource } from "reltab";
-import { ExportFormat } from "tadviewer";
+import { ExportFormat, ParquetExportOptions } from "tadviewer";
 import path from "path";
 
 export const openExportBeginDialog = async (
@@ -22,12 +22,13 @@ export const exportFile = async (
   exportFormat: ExportFormat,
   exportPath: string,
   filterRowCount: number,
-  query: reltab.QueryExp
+  query: reltab.QueryExp,
+  parquetExportOptions: ParquetExportOptions
 ) => {
   if (exportFormat === "csv") {
     return exportCSV(win, exportPath, filterRowCount, query);
   } else if (exportFormat === "parquet") {
-    return exportParquet(win, exportPath, filterRowCount, query);
+    return exportParquet(win, exportPath, query, parquetExportOptions);
   } else {
     console.error("Unsupported export format: ", exportFormat);
   }
@@ -36,8 +37,8 @@ export const exportFile = async (
 const exportParquet = async (
   win: BrowserWindow,
   saveFilename: string,
-  filterRowCount: number,
-  query: reltab.QueryExp
+  query: reltab.QueryExp,
+  parquetExportOptions: ParquetExportOptions
 ) => {
   let exportPercent = 0;
   const exportPathBaseName = path.basename(saveFilename);
@@ -52,7 +53,7 @@ const exportParquet = async (
 
     const baseQuery = await appRtc.getSqlForQuery(query);
 
-    const copyQuery = `COPY (${baseQuery}) TO '${saveFilename}' (FORMAT 'parquet')`;
+    const copyQuery = `COPY (${baseQuery}) TO '${saveFilename}' (FORMAT 'parquet', COMPRESSION '${parquetExportOptions.compression}')`;
 
     const rows = await appRtc.db.runSqlQuery(copyQuery);
   } catch (rawErr) {

--- a/packages/tad-app/src/electronRenderMain.tsx
+++ b/packages/tad-app/src/electronRenderMain.tsx
@@ -5,7 +5,7 @@ import "source-map-support/register";
 import * as React from "react";
 import * as ReactDOM from "react-dom/client";
 import OneRef, { mkRef, refContainer, mutableGet, StateRef } from "oneref";
-import { AppPane, AppPaneBaseProps } from "tadviewer";
+import { AppPane, AppPaneBaseProps, ExportFormat } from "tadviewer";
 import { PivotRequester } from "tadviewer";
 import { AppState } from "tadviewer";
 import { ViewParams, actions } from "tadviewer";
@@ -130,7 +130,12 @@ const init = async () => {
         clipboard={clipboard}
         openURL={openURL}
         embedded={false}
-        onBrowseExportPath={() => ipcRenderer.send("browse-export-path")}
+        onBrowseExportPath={(exportFormat: ExportFormat) =>
+          ipcRenderer.send("browse-export-path", { exportFormat })
+        }
+        onExportFile={(exportFormat: ExportFormat, exportPath: string) =>
+          ipcRenderer.send("export-file", { exportFormat, exportPath })
+        }
       />
     );
     const tRender = performance.now();
@@ -178,6 +183,11 @@ const init = async () => {
     ipcRenderer.on("open-export-begin-dialog", (event, req) => {
       const { openState, saveFilename } = req;
       actions.setExportBeginDialogOpen(openState, stateRef);
+    });
+    ipcRenderer.on("open-export-progress-dialog", (event, req) => {
+      console.log("got open-export-progress-dialog: ", req);
+      const { openState, saveFilename } = req;
+      actions.setExportProgressDialogOpen(openState, saveFilename, stateRef);
     });
     ipcRenderer.on("set-export-path", (event, req) => {
       const { exportPath } = req;

--- a/packages/tad-app/src/electronRenderMain.tsx
+++ b/packages/tad-app/src/electronRenderMain.tsx
@@ -5,7 +5,12 @@ import "source-map-support/register";
 import * as React from "react";
 import * as ReactDOM from "react-dom/client";
 import OneRef, { mkRef, refContainer, mutableGet, StateRef } from "oneref";
-import { AppPane, AppPaneBaseProps, ExportFormat } from "tadviewer";
+import {
+  AppPane,
+  AppPaneBaseProps,
+  ExportFormat,
+  ParquetExportOptions,
+} from "tadviewer";
 import { PivotRequester } from "tadviewer";
 import { AppState } from "tadviewer";
 import { ViewParams, actions } from "tadviewer";
@@ -133,8 +138,16 @@ const init = async () => {
         onBrowseExportPath={(exportFormat: ExportFormat) =>
           ipcRenderer.send("browse-export-path", { exportFormat })
         }
-        onExportFile={(exportFormat: ExportFormat, exportPath: string) =>
-          ipcRenderer.send("export-file", { exportFormat, exportPath })
+        onExportFile={(
+          exportFormat: ExportFormat,
+          exportPath: string,
+          parquetExportOptions: ParquetExportOptions
+        ) =>
+          ipcRenderer.send("export-file", {
+            exportFormat,
+            exportPath,
+            parquetExportOptions,
+          })
         }
       />
     );
@@ -164,7 +177,7 @@ const init = async () => {
       actions.setShowHiddenCols(val, stateRef);
     });
     ipcRenderer.on("request-serialize-filter-query", (event, req) => {
-      console.log("got request-serialize-filter-query: ", req);
+      // console.log("got request-serialize-filter-query: ", req);
       const { requestId } = req;
       const curState = mutableGet(stateRef);
       const baseQuery = curState.viewState.baseQuery;
@@ -208,9 +221,7 @@ const init = async () => {
       openFromOpenParams(openParams, stateRef);
     });
 
-    document.addEventListener("copy", function (e) {
-      console.log("**** renderMain: got copy event");
-    });
+    document.addEventListener("copy", function (e) {});
 
     ipcRenderer.send("render-init-complete");
   } catch (e) {

--- a/packages/tad-app/src/electronRenderMain.tsx
+++ b/packages/tad-app/src/electronRenderMain.tsx
@@ -130,6 +130,7 @@ const init = async () => {
         clipboard={clipboard}
         openURL={openURL}
         embedded={false}
+        onBrowseExportPath={() => ipcRenderer.send("browse-export-path")}
       />
     );
     const tRender = performance.now();
@@ -174,9 +175,13 @@ const init = async () => {
         contents,
       });
     });
-    ipcRenderer.on("open-export-dialog", (event, req) => {
+    ipcRenderer.on("open-export-begin-dialog", (event, req) => {
       const { openState, saveFilename } = req;
-      actions.setExportDialogOpen(openState, saveFilename, stateRef);
+      actions.setExportBeginDialogOpen(openState, stateRef);
+    });
+    ipcRenderer.on("set-export-path", (event, req) => {
+      const { exportPath } = req;
+      actions.setExportPath(exportPath, stateRef);
     });
     ipcRenderer.on("export-progress", (event, req) => {
       const { percentComplete } = req;

--- a/packages/tad-app/src/electronRenderMain.tsx
+++ b/packages/tad-app/src/electronRenderMain.tsx
@@ -185,9 +185,15 @@ const init = async () => {
       actions.setExportBeginDialogOpen(openState, stateRef);
     });
     ipcRenderer.on("open-export-progress-dialog", (event, req) => {
-      console.log("got open-export-progress-dialog: ", req);
-      const { openState, saveFilename } = req;
-      actions.setExportProgressDialogOpen(openState, saveFilename, stateRef);
+      const { openState, exportPathBaseName } = req;
+      actions.setExportProgressDialogOpen(
+        openState,
+        exportPathBaseName,
+        stateRef
+      );
+    });
+    ipcRenderer.on("close-export-progress-dialog", (event, req) => {
+      actions.setExportProgressDialogOpen(false, "", stateRef);
     });
     ipcRenderer.on("set-export-path", (event, req) => {
       const { exportPath } = req;

--- a/packages/tadviewer/src/AppState.ts
+++ b/packages/tadviewer/src/AppState.ts
@@ -10,6 +10,8 @@ import { Activity } from "./components/defs";
  * Just a single view in a single untabbed window for now.
  */
 
+export type ExportFormat = "csv" | "parquet";
+
 export interface AppStateProps {
   initialized: boolean; // Has main process initialization completed?
 
@@ -20,6 +22,7 @@ export interface AppStateProps {
   viewState: ViewState | null;
   exportBeginDialogOpen: boolean;
   exportProgressDialogOpen: boolean;
+  exportFormat: ExportFormat;
   exportPath: string;
   exportPercent: number;
 
@@ -38,6 +41,7 @@ const defaultAppStateProps: AppStateProps = {
   viewState: null,
   exportBeginDialogOpen: false,
   exportProgressDialogOpen: false,
+  exportFormat: "parquet",
   exportPath: "",
   exportPercent: 0,
   viewConfirmDialogOpen: false,
@@ -55,7 +59,9 @@ export class AppState extends Immutable.Record(defaultAppStateProps) {
   public readonly rtc!: reltab.ReltabConnection;
 
   public readonly viewState!: ViewState;
-  public readonly exportDialogOpen!: boolean;
+  public readonly exportBeginDialogOpen!: boolean;
+  public readonly exportProgressDialogOpen!: boolean;
+  public readonly exportFormat!: ExportFormat;
   public readonly exportPath!: string;
   public readonly exportPercent!: number;
   public readonly viewConfirmDialogOpen!: boolean;

--- a/packages/tadviewer/src/AppState.ts
+++ b/packages/tadviewer/src/AppState.ts
@@ -18,8 +18,9 @@ export interface AppStateProps {
   rtc: reltab.ReltabConnection | null;
 
   viewState: ViewState | null;
-  exportDialogOpen: boolean;
-  exportFilename: string;
+  exportBeginDialogOpen: boolean;
+  exportProgressDialogOpen: boolean;
+  exportPath: string;
   exportPercent: number;
 
   viewConfirmDialogOpen: boolean;
@@ -35,8 +36,9 @@ const defaultAppStateProps: AppStateProps = {
   windowTitle: "",
   rtc: null,
   viewState: null,
-  exportDialogOpen: false,
-  exportFilename: "",
+  exportBeginDialogOpen: false,
+  exportProgressDialogOpen: false,
+  exportPath: "",
   exportPercent: 0,
   viewConfirmDialogOpen: false,
   viewConfirmSourcePath: null,
@@ -54,7 +56,7 @@ export class AppState extends Immutable.Record(defaultAppStateProps) {
 
   public readonly viewState!: ViewState;
   public readonly exportDialogOpen!: boolean;
-  public readonly exportFilename!: string;
+  public readonly exportPath!: string;
   public readonly exportPercent!: number;
   public readonly viewConfirmDialogOpen!: boolean;
   public readonly viewConfirmSourcePath!: DataSourcePath | null;

--- a/packages/tadviewer/src/AppState.ts
+++ b/packages/tadviewer/src/AppState.ts
@@ -12,6 +12,14 @@ import { Activity } from "./components/defs";
 
 export type ExportFormat = "csv" | "parquet";
 
+export interface ParquetExportOptions {
+  compression: "uncompressed" | "snappy" | "gzip" | "zstd";
+}
+
+export const defaultParquetExportOptions: ParquetExportOptions = {
+  compression: "snappy",
+};
+
 export interface AppStateProps {
   initialized: boolean; // Has main process initialization completed?
 

--- a/packages/tadviewer/src/AppState.ts
+++ b/packages/tadviewer/src/AppState.ts
@@ -24,6 +24,7 @@ export interface AppStateProps {
   exportProgressDialogOpen: boolean;
   exportFormat: ExportFormat;
   exportPath: string;
+  exportPathBaseName: string;
   exportPercent: number;
 
   viewConfirmDialogOpen: boolean;
@@ -43,6 +44,7 @@ const defaultAppStateProps: AppStateProps = {
   exportProgressDialogOpen: false,
   exportFormat: "parquet",
   exportPath: "",
+  exportPathBaseName: "",
   exportPercent: 0,
   viewConfirmDialogOpen: false,
   viewConfirmSourcePath: null,
@@ -63,6 +65,7 @@ export class AppState extends Immutable.Record(defaultAppStateProps) {
   public readonly exportProgressDialogOpen!: boolean;
   public readonly exportFormat!: ExportFormat;
   public readonly exportPath!: string;
+  public readonly exportPathBaseName!: string;
   public readonly exportPercent!: number;
   public readonly viewConfirmDialogOpen!: boolean;
   public readonly viewConfirmSourcePath!: DataSourcePath | null;

--- a/packages/tadviewer/src/actions.ts
+++ b/packages/tadviewer/src/actions.ts
@@ -472,15 +472,16 @@ export const setExportBeginDialogOpen = (
 
 export const setExportProgressDialogOpen = (
   openState: boolean,
-  saveFilename: string,
+  exportPathBaseName: string,
   stateRef: StateRef<AppState>
 ) => {
+  console.log("exportProgressDialogOpen: ", exportPathBaseName);
   update(
     stateRef,
     (s) =>
       s
         .set("exportProgressDialogOpen", openState)
-        .set("exportPath", saveFilename) as AppState
+        .set("exportPathBaseName", exportPathBaseName) as AppState
   );
 };
 export const setExportFormat = (

--- a/packages/tadviewer/src/actions.ts
+++ b/packages/tadviewer/src/actions.ts
@@ -463,7 +463,14 @@ export const setShowHiddenCols = (
   );
 };
 
-export const setExportDialogOpen = (
+export const setExportBeginDialogOpen = (
+  openState: boolean,
+  stateRef: StateRef<AppState>
+) => {
+  update(stateRef, (s) => s.set("exportBeginDialogOpen", openState));
+};
+
+export const setExportProgressDialogOpen = (
   openState: boolean,
   saveFilename: string,
   stateRef: StateRef<AppState>
@@ -472,9 +479,15 @@ export const setExportDialogOpen = (
     stateRef,
     (s) =>
       s
-        .set("exportDialogOpen", openState)
-        .set("exportFilename", saveFilename) as AppState
+        .set("exportProgressDialogOpen", openState)
+        .set("exportPath", saveFilename) as AppState
   );
+};
+export const setExportPath = (
+  exportPath: string,
+  stateRef: StateRef<AppState>
+) => {
+  update(stateRef, (s) => s.set("exportPath", exportPath));
 };
 
 export const setViewConfirmDialogOpen = (

--- a/packages/tadviewer/src/actions.ts
+++ b/packages/tadviewer/src/actions.ts
@@ -1,6 +1,6 @@
 import { ViewParams } from "./ViewParams";
 import { ViewState } from "./ViewState";
-import { AppState } from "./AppState";
+import { AppState, ExportFormat } from "./AppState";
 import * as reltab from "reltab";
 import { Activity, ColumnListTypes } from "./components/defs";
 import { Path, PathTree } from "aggtree";
@@ -483,6 +483,13 @@ export const setExportProgressDialogOpen = (
         .set("exportPath", saveFilename) as AppState
   );
 };
+export const setExportFormat = (
+  exportFormat: ExportFormat,
+  stateRef: StateRef<AppState>
+) => {
+  update(stateRef, (s) => s.set("exportFormat", exportFormat));
+};
+
 export const setExportPath = (
   exportPath: string,
   stateRef: StateRef<AppState>

--- a/packages/tadviewer/src/components/AppPane.tsx
+++ b/packages/tadviewer/src/components/AppPane.tsx
@@ -278,11 +278,7 @@ const ExportBeginDialog: React.FunctionComponent<ExportBeginDialogProps> = ({
     >
       <div className={Classes.DIALOG_BODY}>
         <p className="bp4-text-large">Export {filterCountStr} rows</p>
-        <FormGroup
-          inline={true}
-          label="File Format"
-          labelFor="export-format-select"
-        >
+        <FormGroup label="File Format" labelFor="export-format-select">
           <HTMLSelect
             id="export-format-select"
             value={exportFormat}

--- a/packages/tadviewer/src/components/AppPane.tsx
+++ b/packages/tadviewer/src/components/AppPane.tsx
@@ -14,6 +14,7 @@ import {
   FormGroup,
   InputGroup,
   HTMLSelect,
+  Text,
 } from "@blueprintjs/core";
 import { GridPane, OpenURLFn } from "./GridPane";
 import { Footer } from "./Footer";
@@ -91,6 +92,7 @@ const ExportProgressDialog: React.FunctionComponent<ExportDialogProps> = ({
   const { viewState, exportPercent } = appState;
 
   const isBusy = exportPercent < 1;
+  const isComplete = !isBusy;
 
   if (
     appState.initialized &&
@@ -107,6 +109,10 @@ const ExportProgressDialog: React.FunctionComponent<ExportDialogProps> = ({
       });
     }
   }
+
+  const exportWord = isBusy ? "Exporting" : "Exported";
+  const exportEllipsis = isBusy ? "..." : "";
+  const exportText = `${exportWord} ${filterCountStr} rows to ${appState.exportPathBaseName}${exportEllipsis}`;
   return (
     <Dialog
       title="Export File"
@@ -114,9 +120,10 @@ const ExportProgressDialog: React.FunctionComponent<ExportDialogProps> = ({
       isOpen={appState.exportProgressDialogOpen}
     >
       <div className={Classes.DIALOG_BODY}>
-        <p className="bp4-text-large">
-          Exporting {filterCountStr} rows to {appState.exportPath}
-        </p>
+        <Text className="bp4-text-large" ellipsize={true}>
+          {exportText}
+        </Text>
+        <br />
         <ProgressBar stripes={isBusy} />
       </div>
       <div className={Classes.DIALOG_FOOTER}>
@@ -212,7 +219,7 @@ const ExportBeginDialog: React.FunctionComponent<ExportBeginDialogProps> = ({
               onExportFile?.(exportFormat, exportPath);
             }}
           >
-            OK
+            Export
           </Button>
         </div>
       </div>


### PR DESCRIPTION
Rework the "Export Filtered CSV" to support both CSV and Parquet export.

Export dialog:

<img width="507" alt="2024-06-19_09-42-10" src="https://github.com/antonycourtney/tad/assets/4683413/2aabba2b-2edb-45f2-8a29-3581633af441">

