### PR TITLE
Render objects and arrays using `JSON.stringify()` instead of `String()`

### DIFF
--- a/packages/reltab/src/ColumnType.ts
+++ b/packages/reltab/src/ColumnType.ts
@@ -47,20 +47,25 @@ type ColumnTypeOpts = {
 };
 
 const defaultValRender: StringRenderFn = (val: any) => {
-  if (val == null) {
+  if (val === null) {
     return "";
   }
-  if (typeof val === "string") {
-    return val;
-  }
-  if (typeof val === "bigint") {
-    return val.toString();
-  }
-  try {
-    return String(val);
-  } catch (err) {
-    console.error("error stringifying value: ", val);
-    return "";
+  switch (typeof val) {
+    case "string":
+      return val;
+
+    case "object":
+      return JSON.stringify(val, (_, v) =>
+        typeof v === "bigint" ? v.toString() : v
+      );
+
+    default:
+      try {
+        return String(val);
+      } catch (err) {
+        console.error("error stringifying value: ", val);
+        return "";
+      }
   }
 };
 

--- a/packages/tadviewer/src/components/DataGrid.tsx
+++ b/packages/tadviewer/src/components/DataGrid.tsx
@@ -341,6 +341,7 @@ const createGrid = (
   props: DataGridProps
 ) => {
   const {
+    getColumnFormatter,
     histoMap,
     onViewportChanged,
     onHistogramBrushRange,
@@ -403,7 +404,10 @@ const createGrid = (
       const copyRow = [];
       for (let col = range.fromCell; col <= range.toCell; col++) {
         const cid = gridCols[col].id;
-        copyRow.push(escapeTabs(rowData[cid]));
+        const cellData = rowData[cid];
+        const formatColumn = getColumnFormatter(gridData.schema, gridCols[col].name);
+        const formattedCellData = formatColumn(cellData);
+        copyRow.push(escapeTabs(formattedCellData));
       }
       copyRowStrings.push(copyRow.join("\t"));
     }


### PR DESCRIPTION
I believe this closes #273.

I adjusted the defaultValRender function in reltab to use JSON.stringify() for objects. This lets Tad show the object's fields instead of just showing `[Object object]`.

In order for copy-pasting to work with this logic, I also changed the `copySelectedRange` function to use the respective column formatter instead of taking the raw value. For some reason, this doesn't seem to respect custom column formatting rules, but it didn't do that before this change either, so I figured that it's probably out of scope for this PR.