### PR TITLE
support custom blob rendering in DuckDBDialect

### DIFF
--- a/packages/reltab/src/dialects/DuckDBDialect.ts
+++ b/packages/reltab/src/dialects/DuckDBDialect.ts
@@ -112,6 +112,9 @@ const blobCT = new ColumnType("BLOB", "blob", {
     if (val == null) {
       return "";
     }
+    if (isDuckDBStringRenderer(val)) {
+      return val.toDuckDBString();
+    }
     if (isNode() && val instanceof Buffer) {
       return val.toString();
     }


### PR DESCRIPTION
In the DuckDBDialect, extend support for the custom string rendering function `toDuckDBString` to values of type BLOB. (It's already support on other types, such as TIMESTAMP.)